### PR TITLE
fix(electron): add graceful-fs to devDependencies for Node.js v25 compat

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -60,6 +60,7 @@
         "electron": "^35.0.0",
         "electron-builder": "^26.0.0",
         "esbuild": "^0.25.0",
+        "graceful-fs": "^4.2.11",
         "jsdom": "^27.0.0",
         "typescript": "^5.7.2",
         "vite": "^7.1.7",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
         "electron": "^35.0.0",
         "electron-builder": "^26.0.0",
         "esbuild": "^0.25.0",
+        "graceful-fs": "^4.2.11",
         "jsdom": "^27.0.0",
         "typescript": "^5.7.2",
         "vite": "^7.1.7",


### PR DESCRIPTION
## Problem

Electron's postinstall script crashes on Node.js v25 when running `bun install`:

```
Error: Cannot find module 'graceful-fs'
```

## Root Cause

`@electron/get@2.0.3` depends on `fs-extra@^8.1.0`, which conflicts with the top-level `fs-extra@10.x`, so Bun installs it nested under `node_modules/@electron/get/node_modules/fs-extra/`. That nested `fs-extra@8.1.0` declares `graceful-fs` as a dependency, but Bun neither hoists it to the top level nor nests it alongside `fs-extra@8.1.0` — it simply goes missing. Node.js v25 is stricter about module resolution and does not fall back gracefully, causing the postinstall crash.

```
@electron/get@2.0.3
  └── fs-extra@^8.1.0  (nested, conflicts with top-level fs-extra@10.x)
        └── graceful-fs@^4.2.0  ← Bun hoisting bug: neither hoisted nor nested
```

## Fix

Explicitly declare `graceful-fs@^4.2.11` as a devDependency so Bun always installs it at the top level, making it resolvable by the Electron postinstall script.

## Notes

- `graceful-fs@4.2.11` is already the version Bun resolves transitively — this change only makes it explicit.
- The upstream fix would be `@electron/get` upgrading `fs-extra` from `^8` to `^10`, which no longer depends on `graceful-fs`.

## Changes

- `package.json`: add `"graceful-fs": "^4.2.11"` to devDependencies
- `bun.lock`: updated accordingly