### PR TITLE
fix(server): add ESM-compatible __dirname polyfill

### DIFF
--- a/server/api/ai/mcp-install.ts
+++ b/server/api/ai/mcp-install.ts
@@ -1,8 +1,12 @@
 import { defineEventHandler, readBody, setResponseHeaders } from 'h3'
 import { homedir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join, resolve, dirname } from 'node:path'
 import { readFile, writeFile, mkdir } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 const MCP_DEFAULT_PORT = 3100
 

--- a/server/utils/mcp-server-manager.ts
+++ b/server/utils/mcp-server-manager.ts
@@ -1,7 +1,11 @@
 import { spawn, execSync, type ChildProcess } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { networkInterfaces } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join, resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 let mcpProcess: ChildProcess | null = null
 let mcpPort: number | null = null


### PR DESCRIPTION
## Summary
- Adds ESM-compatible `__dirname` polyfill using `fileURLToPath` and `dirname`
- Fixes browser version crash with `__dirname is not defined`
- Fixes MCP over HTTP transport failure introduced in v3.3

## Root Cause
OpenPencil uses `"type": "module"` (ESM), but `__dirname` is a CommonJS-only global. The switch from `fork()` to `spawn()` in v3.3 exposed this bug by changing error propagation behavior.

## Files Changed
- `server/api/ai/mcp-install.ts` — path resolution for MCP server
- `server/utils/mcp-server-manager.ts` — path resolution for HTTP transport

## Testing
- [ ] Browser version starts without `__dirname` error
- [ ] MCP over HTTP starts successfully
- [ ] MCP STDIO transport still works
- [ ] Electron production build still works

Fixes #37