### PR TITLE
fix: avoid 1-frame delay when resizing canvas

### DIFF
--- a/src/canvas/skia/skia-engine.ts
+++ b/src/canvas/skia/skia-engine.ts
@@ -462,7 +462,7 @@ export class SkiaEngine {
     if (!this.surface) {
       this.surface = this.ck.MakeSWCanvasSurface(this.canvasEl)
     }
-    this.markDirty()
+    this.render()
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix flickering during canvas resize by ensuring rendering happens in the same frame.

## Changes

- Call `render()` synchronously inside ResizeObserver
- Avoid scheduling render via rAF, which introduces a 1-frame delay
- Ensure canvas updates before paint to prevent visible flicker when dragging the panel

## Related Issues

<!-- N/A -->

## Type

- [x] `fix` — Bug fix
- [ ] `feat` — New feature
- [ ] `refactor` — Code refactoring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation
- [ ] `test` — Tests
- [ ] `chore` — Build / tooling / dependencies

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `bun --bun run test` passes
- [x] No unrelated changes included
- [x] Commit messages follow Conventional Commits