### PR TITLE
perf(canvas): skip draw calls for nodes outside the viewport

### DIFF
--- a/apps/web/src/canvas/skia/skia-engine.ts
+++ b/apps/web/src/canvas/skia/skia-engine.ts
@@ -16,6 +16,8 @@ import {
   premeasureTextHeights,
   collectReusableIds,
   collectInstanceIds,
+  getViewportBounds,
+  isRectInViewport,
 } from '@zseven-w/pen-renderer'
 import {
   getActiveAgentIndicators,
@@ -211,8 +213,16 @@ export class SkiaEngine {
     // Pass current zoom to renderer for zoom-aware text rasterization
     this.renderer.zoom = this.zoom
 
+    const vpBounds = getViewportBounds(
+      { zoom: this.zoom, panX: this.panX, panY: this.panY },
+      this.canvasEl.clientWidth,
+      this.canvasEl.clientHeight,
+      64 / this.zoom
+    )
     // Draw all render nodes
     for (const rn of this.renderNodes) {
+      // Skip nodes outside the viewport
+      if (!isRectInViewport({ x: rn.absX, y: rn.absY, w: rn.absW, h: rn.absH }, vpBounds)) continue
       this.renderer.drawNodeWithSelection(canvas, rn, selectedIds)
     }
 


### PR DESCRIPTION
  Add viewport culling in render() to avoid issuing CanvasKit draw calls
  for off-screen nodes. A 64px screen-space buffer is kept around the
  viewport edges so nearby nodes are pre-rendered, preventing pop-in
  during fast panning.

## Summary

Improve canvas rendering performance by skipping draw calls for nodes outside the viewport. A 64px screen-space buffer is used around the viewport to pre-render nearby nodes, reducing pop-in during fast panning.

## Changes

Added viewport culling in render() to avoid drawing off-screen nodes.

Preserved a 64px buffer around viewport edges for smooth rendering during fast panning.

## Type

- [x] `perf` — Performance improvement

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `bun --bun run test` passes
- [x] No unrelated changes included
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Performance
### Test Scenario
The performance gain is most significant in the following scenario:

- Action: Rapidly "shaking" or panning the canvas at high speeds.

- Environment: A massive project containing thousands of nodes.

- Zoom State: High zoom level where only a small subset of nodes is visible.
### Test Code
```
private lastFrameTime = performance.now()
private fps = 0
private fpsHistory: number[] = []
private render() {
    const now = performance.now()
    const delta = now - this.lastFrameTime
    this.lastFrameTime = now

    this.fps = 1000 / delta
    this.fpsHistory.push(this.fps)
    if (this.fpsHistory.length > 100) this.fpsHistory.shift() // 

    performance.mark('render-start');
    
    ......

    performance.mark('render-end')
    performance.measure('render', 'render-start', 'render-end')

    console.table(this.fpsHistory.map((f, i) => ({ frame: i + 1, fps: f.toFixed(0) })))
}

```

Before fps
<img width="676" height="436" alt="image" src="https://github.com/user-attachments/assets/e5fe4498-07c0-4d1d-85c4-6fe6a4d3cc92" />

After fps
<img width="614" height="440" alt="image" src="https://github.com/user-attachments/assets/24d84bca-7819-47c1-a2ce-5ea42d8f3d0f" />
