### PR TITLE
fix: stabilize electron dev sync and bitmap dragging

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,9 @@
+# -----------------------------------------------------------------------------
+# OpenPencil 本地开发默认环境
+# -----------------------------------------------------------------------------
+
+# 本地 dev server 与 Electron 都依赖 loopback 回环地址互相访问。
+# 如果系统启用了 http_proxy / https_proxy / all_proxy, 但没有 NO_PROXY,
+# 本地 SSR 文档请求会被错误转发给代理并返回 502。
+export NO_PROXY="${NO_PROXY:-127.0.0.1,localhost,::1}"
+export no_proxy="${no_proxy:-127.0.0.1,localhost,::1}"

--- a/apps/desktop/dev.ts
+++ b/apps/desktop/dev.ts
@@ -9,8 +9,10 @@
 
 import { spawn, execSync, type ChildProcess } from 'node:child_process'
 import { build } from 'esbuild'
+import { Socket } from 'node:net'
 import { join } from 'node:path'
 import { compileSkills } from '../../packages/pen-ai-skills/vite-plugin-skills'
+import { ensureLoopbackNoProxy, withLoopbackNoProxy } from '../../scripts/loopback-no-proxy'
 
 const DESKTOP_DIR = import.meta.dirname
 const ROOT = join(DESKTOP_DIR, '..', '..')
@@ -24,13 +26,36 @@ async function waitForServer(
   url: string,
   timeoutMs = 30_000,
 ): Promise<void> {
+  const target = new URL(url)
+  const port = Number.parseInt(target.port || '80', 10)
+  const hosts = target.hostname === 'localhost'
+    ? ['127.0.0.1', '::1', 'localhost']
+    : [target.hostname]
   const start = Date.now()
+
+  async function canConnect(host: string): Promise<boolean> {
+    return await new Promise((resolve) => {
+      const socket = new Socket()
+
+      const finish = (ok: boolean) => {
+        socket.removeAllListeners()
+        socket.destroy()
+        resolve(ok)
+      }
+
+      socket.setTimeout(800)
+      socket.once('connect', () => finish(true))
+      socket.once('timeout', () => finish(false))
+      socket.once('error', () => finish(false))
+      socket.connect(port, host)
+    })
+  }
+
   while (Date.now() - start < timeoutMs) {
-    try {
-      const res = await fetch(url)
-      if (res.ok || res.status < 500) return
-    } catch {
-      // server not ready yet
+    for (const host of hosts) {
+      if (await canConnect(host)) {
+        return
+      }
     }
     await new Promise((r) => setTimeout(r, 500))
   }
@@ -68,12 +93,17 @@ async function compileElectron(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
+  // 当前进程本身也会探活 localhost。
+  // 这里继续保留 loopback no_proxy, 让后续若有 fetch/子进程也统一走直连。
+  ensureLoopbackNoProxy(process.env)
+  const childEnv = withLoopbackNoProxy(process.env)
+
   // 1. Start Vite dev server
   console.log('[electron-dev] Starting Vite dev server...')
   const vite = spawn('bun', ['--bun', 'run', 'dev'], {
     cwd: ROOT,
     stdio: 'inherit',
-    env: { ...process.env },
+    env: childEnv,
   })
 
   // Ensure cleanup on exit
@@ -120,7 +150,7 @@ async function main(): Promise<void> {
   const electron = spawn(electronBin, [join(ROOT, 'out', 'desktop', 'main.cjs')], {
     cwd: ROOT,
     stdio: 'inherit',
-    env: { ...process.env },
+    env: childEnv,
   }) as ChildProcess
 
   electron.on('exit', () => {

--- a/apps/web/dev.ts
+++ b/apps/web/dev.ts
@@ -1,0 +1,23 @@
+import { spawn } from 'node:child_process'
+
+import { withLoopbackNoProxy } from '../../scripts/loopback-no-proxy'
+
+/**
+ * 在真正启动 Vite 前先补齐本地回环地址的代理绕过规则。
+ *
+ * 这一步必须发生在 Vite 进程启动之前。
+ * 否则带代理环境下, SSR 文档请求仍可能被错误送去代理并返回 502。
+ */
+const child = spawn('bun', ['--bun', 'vite', 'dev', '--port', '3000'], {
+  cwd: import.meta.dirname,
+  stdio: 'inherit',
+  env: withLoopbackNoProxy(process.env),
+})
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal)
+    return
+  }
+  process.exit(code ?? 0)
+})

--- a/apps/web/server/api/mcp/document.post.ts
+++ b/apps/web/server/api/mcp/document.post.ts
@@ -1,5 +1,6 @@
-import { defineEventHandler, readBody, createError } from 'h3'
+import { defineEventHandler, readBody, createError, getRequestHeader, setResponseStatus } from 'h3'
 import { setSyncDocument } from '../../utils/mcp-sync-state'
+import { serverLog } from '../../utils/server-logger'
 import type { PenDocument } from '../../../src/types/pen'
 
 interface PostBody {
@@ -7,16 +8,135 @@ interface PostBody {
   sourceClientId?: string
 }
 
+interface DocumentStats {
+  nodeCount: number
+  imageCount: number
+  dataUrlImageCount: number
+  dataUrlChars: number
+}
+
+function collectDocumentStats(doc: PenDocument): DocumentStats {
+  const stats: DocumentStats = {
+    nodeCount: 0,
+    imageCount: 0,
+    dataUrlImageCount: 0,
+    dataUrlChars: 0,
+  }
+
+  const visit = (nodes?: unknown): void => {
+    if (!Array.isArray(nodes)) return
+    for (const node of nodes) {
+      if (!node || typeof node !== 'object') continue
+      stats.nodeCount++
+
+      const typedNode = node as {
+        type?: string
+        src?: string
+        children?: unknown
+      }
+
+      if (typedNode.type === 'image') {
+        stats.imageCount++
+        if (typeof typedNode.src === 'string' && typedNode.src.startsWith('data:')) {
+          stats.dataUrlImageCount++
+          stats.dataUrlChars += typedNode.src.length
+        }
+      }
+
+      visit(typedNode.children)
+    }
+  }
+
+  visit(doc.children)
+  if (Array.isArray(doc.pages)) {
+    for (const page of doc.pages) {
+      visit(page?.children)
+    }
+  }
+
+  return stats
+}
+
+function formatBytes(bytes: number | null): string {
+  if (bytes == null || Number.isNaN(bytes)) return 'unknown'
+  if (bytes < 1024) return `${bytes}B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KiB`
+  return `${(bytes / (1024 * 1024)).toFixed(2)}MiB`
+}
+
+function isConnectionClosedError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false
+  const maybeError = error as { name?: string; message?: string; cause?: unknown }
+  const message = maybeError.message ?? ''
+  const causeMessage = typeof maybeError.cause === 'object' && maybeError.cause
+    ? String((maybeError.cause as { message?: string }).message ?? '')
+    : ''
+
+  return maybeError.name === 'AbortError'
+    || /connection was closed/i.test(message)
+    || /connection was closed/i.test(causeMessage)
+    || /abort/i.test(message)
+}
+
 /** POST /api/mcp/document — Receives document update from MCP or renderer, triggers SSE broadcast. */
 export default defineEventHandler(async (event) => {
-  const body = await readBody<PostBody>(event)
-  if (!body?.document) {
-    throw createError({ statusCode: 400, statusMessage: 'Missing document in request body' })
+  const startedAt = Date.now()
+  const contentLengthHeader = getRequestHeader(event, 'content-length')
+  const bodyBytesHeader = getRequestHeader(event, 'x-openpencil-body-bytes')
+  const contentLength = contentLengthHeader
+    ? Number.parseInt(contentLengthHeader, 10)
+    : bodyBytesHeader
+      ? Number.parseInt(bodyBytesHeader, 10)
+      : null
+  const sourceClientIdHeader = getRequestHeader(event, 'x-openpencil-client-id') ?? 'unknown'
+  let phase = 'readBody'
+
+  try {
+    const body = await readBody<PostBody>(event)
+    if (!body?.document) {
+      throw createError({ statusCode: 400, statusMessage: 'Missing document in request body' })
+    }
+    const doc = body.document
+    if (!doc.version || (!Array.isArray(doc.children) && !Array.isArray(doc.pages))) {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid document format' })
+    }
+
+    const stats = collectDocumentStats(doc)
+    phase = 'setSyncDocument'
+    const version = setSyncDocument(doc, body.sourceClientId)
+    const elapsedMs = Date.now() - startedAt
+
+    serverLog.info(
+      `[mcp-document] ok version=${version} sourceClientId=${body.sourceClientId ?? sourceClientIdHeader} ` +
+      `contentLength=${formatBytes(contentLength)} nodes=${stats.nodeCount} images=${stats.imageCount} ` +
+      `dataUrlImages=${stats.dataUrlImageCount} dataUrlChars=${stats.dataUrlChars} elapsedMs=${elapsedMs}`,
+    )
+
+    return { ok: true, version }
+  } catch (error) {
+    const elapsedMs = Date.now() - startedAt
+    const message = error instanceof Error ? error.message : String(error)
+
+    if (isConnectionClosedError(error)) {
+      serverLog.warn(
+        `[mcp-document] connection-closed phase=${phase} contentLength=${formatBytes(contentLength)} ` +
+        `sourceClientId=${sourceClientIdHeader} elapsedMs=${elapsedMs} message=${message}`,
+      )
+
+      // 这类请求在 readBody 阶段就已经被客户端中断。
+      // 继续抛错只会把预期内的同步噪音放大成 Vite/Nitro 500 日志。
+      setResponseStatus(event, 202, 'Client closed request during MCP document sync')
+      return {
+        ok: false,
+        aborted: true,
+        phase,
+      }
+    }
+
+    serverLog.error(
+      `[mcp-document] failed phase=${phase} contentLength=${formatBytes(contentLength)} ` +
+      `sourceClientId=${sourceClientIdHeader} elapsedMs=${elapsedMs} message=${message}`,
+    )
+    throw error
   }
-  const doc = body.document
-  if (!doc.version || (!Array.isArray(doc.children) && !Array.isArray(doc.pages))) {
-    throw createError({ statusCode: 400, statusMessage: 'Invalid document format' })
-  }
-  const version = setSyncDocument(doc, body.sourceClientId)
-  return { ok: true, version }
 })

--- a/apps/web/server/utils/mcp-sync-state.ts
+++ b/apps/web/server/utils/mcp-sync-state.ts
@@ -57,13 +57,21 @@ export function unregisterSSEClient(id: string): void {
 }
 
 function broadcast(payload: Record<string, unknown>, excludeClientId?: string): void {
-  const data = JSON.stringify(payload)
+  const recipients: SSEClient[] = []
   for (const [id, client] of clients) {
     if (id === excludeClientId) continue
+    recipients.push(client)
+  }
+
+  // 没有接收者时直接返回, 避免对大文档做无意义的 JSON 序列化。
+  if (recipients.length === 0) return
+
+  const data = JSON.stringify(payload)
+  for (const client of recipients) {
     try {
       client.writer.push(data)
     } catch {
-      clients.delete(id)
+      clients.delete(client.id)
     }
   }
 }

--- a/apps/web/src/canvas/skia/skia-interaction.ts
+++ b/apps/web/src/canvas/skia/skia-interaction.ts
@@ -35,6 +35,14 @@ export function toolToCursor(tool: ToolType): string {
   }
 }
 
+function hasImageVisual(node: PenNode | undefined): boolean {
+  if (!node) return false
+  if (node.type === 'image') return true
+  if (!('fill' in node)) return false
+  return Array.isArray(node.fill)
+    && node.fill.some((fill) => fill?.type === 'image')
+}
+
 /**
  * Encapsulates all canvas mouse/keyboard interaction state and handlers.
  * Extracted from SkiaCanvas to keep the component focused on lifecycle and rendering.
@@ -242,8 +250,13 @@ export class SkiaInteractionManager {
       if (isChildOfSelected) {
         // Don't change selection
       } else if (!currentSelection.includes(nodeId)) {
+        const clickedNode = docStore.getNodeById(nodeId)
         const parent = docStore.getParentOf(nodeId)
-        if (parent && (parent.type === 'frame' || parent.type === 'group')) {
+        if (
+          !hasImageVisual(clickedNode)
+          && parent
+          && (parent.type === 'frame' || parent.type === 'group')
+        ) {
           const grandparent = docStore.getParentOf(parent.id)
           if (!grandparent || grandparent.type === 'frame') {
             nodeId = parent.id
@@ -486,6 +499,13 @@ export class SkiaInteractionManager {
       if (this.dragAllIds!.has(rn.node.id)) {
         rn.absX += incrDx
         rn.absY += incrDy
+        if (rn.clipRect) {
+          rn.clipRect = {
+            ...rn.clipRect,
+            x: rn.clipRect.x + incrDx,
+            y: rn.clipRect.y + incrDy,
+          }
+        }
         rn.node = { ...rn.node, x: rn.absX, y: rn.absY }
       }
     }

--- a/apps/web/src/hooks/use-mcp-sync.ts
+++ b/apps/web/src/hooks/use-mcp-sync.ts
@@ -7,18 +7,46 @@ const PUSH_DEBOUNCE_MS = 2000
 const SELECTION_DEBOUNCE_MS = 300
 const RECONNECT_DELAY_MS = 3000
 const MAX_RECONNECT_ATTEMPTS = 3
+const SYNC_MAX_BODY_BYTES = 2 * 1024 * 1024
+
+let oversizeSyncWarned = false
 
 function getBaseUrl(): string {
   return window.location.origin
 }
 
-function pushDocumentToServer(clientId: string | null) {
+async function pushDocumentToServer(clientId: string | null) {
   const doc = useDocumentStore.getState().document
-  fetch(`${getBaseUrl()}/api/mcp/document`, {
+  const body = JSON.stringify({ document: doc, sourceClientId: clientId })
+  const bodyBytes = new TextEncoder().encode(body).byteLength
+
+  if (bodyBytes > SYNC_MAX_BODY_BYTES) {
+    if (!oversizeSyncWarned) {
+      oversizeSyncWarned = true
+      console.warn(
+        `[mcp-sync] Skip oversized document push: ${(
+          bodyBytes / (1024 * 1024)
+        ).toFixed(2)}MiB > ${(SYNC_MAX_BODY_BYTES / (1024 * 1024)).toFixed(2)}MiB`,
+      )
+    }
+    return
+  }
+
+  oversizeSyncWarned = false
+
+  await fetch(`${getBaseUrl()}/api/mcp/document`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ document: doc, sourceClientId: clientId }),
-  }).catch(() => {})
+    headers: {
+      'Content-Type': 'application/json',
+      'x-openpencil-client-id': clientId ?? 'renderer:unknown',
+      'x-openpencil-body-bytes': String(bodyBytes),
+    },
+    // 小请求在页面切换 / HMR 时尽量继续发完, 降低“客户端刚好中断”概率。
+    ...(bodyBytes <= 60_000 ? { keepalive: true } : {}),
+    // 给大文档同步留出更长的本地回环传输窗口, 避免默认超时过早打断。
+    signal: AbortSignal.timeout(30_000),
+    body,
+  })
 }
 
 /**
@@ -29,6 +57,9 @@ function pushDocumentToServer(clientId: string | null) {
 export function useMcpSync() {
   const clientIdRef = useRef<string | null>(null)
   const pushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pushInFlightRef = useRef(false)
+  const pushQueuedRef = useRef(false)
+  const queuedClientIdRef = useRef<string | null>(null)
   // Skip debounce pushes briefly after applying an external document.
   // Use a timestamp instead of a boolean so cascading setState calls
   // (e.g. canvas sync page switch handler) are also suppressed.
@@ -40,6 +71,30 @@ export function useMcpSync() {
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null
     let disposed = false
     let reconnectAttempts = 0
+
+    async function flushDocumentPush(clientId: string | null) {
+      if (disposed) return
+      if (pushInFlightRef.current) {
+        pushQueuedRef.current = true
+        queuedClientIdRef.current = clientId
+        return
+      }
+
+      pushInFlightRef.current = true
+      try {
+        await pushDocumentToServer(clientId)
+      } catch {
+        // MCP sync 是增强能力, 失败时不打断主编辑器流程。
+      } finally {
+        pushInFlightRef.current = false
+        if (pushQueuedRef.current && !disposed) {
+          const nextClientId = queuedClientIdRef.current
+          pushQueuedRef.current = false
+          queuedClientIdRef.current = null
+          void flushDocumentPush(nextClientId)
+        }
+      }
+    }
 
     function connect() {
       if (disposed) return
@@ -53,7 +108,7 @@ export function useMcpSync() {
           if (data.type === 'client:id') {
             clientIdRef.current = data.clientId
             // Push current document so MCP can read it immediately
-            pushDocumentToServer(data.clientId)
+            void flushDocumentPush(data.clientId)
           } else if (data.type === 'document:update' || data.type === 'document:init') {
             const doc = data.document as PenDocument
             const childCount = doc.pages?.[0]?.children?.length ?? doc.children?.length ?? 0
@@ -93,17 +148,20 @@ export function useMcpSync() {
     // On loadDocument/newDocument (isDirty transitions to false), push
     // immediately so the server cache is replaced without waiting 2s.
     const unsubDoc = useDocumentStore.subscribe((state, prevState) => {
+      const documentChanged = state.document !== prevState.document
+      const dirtyChanged = state.isDirty !== prevState.isDirty
+      if (!documentChanged && !dirtyChanged) return
       if (Date.now() < skipPushUntilRef.current) return
       if (pushTimerRef.current) clearTimeout(pushTimerRef.current)
 
       const isLoadEvent = !state.isDirty && prevState.isDirty !== state.isDirty
       if (isLoadEvent) {
-        pushDocumentToServer(clientIdRef.current)
+        void flushDocumentPush(clientIdRef.current)
         return
       }
 
       pushTimerRef.current = setTimeout(() => {
-        pushDocumentToServer(clientIdRef.current)
+        void flushDocumentPush(clientIdRef.current)
       }, PUSH_DEBOUNCE_MS)
     })
 

--- a/apps/web/src/mcp/document-manager.ts
+++ b/apps/web/src/mcp/document-manager.ts
@@ -243,10 +243,16 @@ async function pushLiveDocument(doc: PenDocument): Promise<void> {
   const syncUrl = cachedUrl ?? await getSyncUrl()
   if (!syncUrl) return
   try {
+    const body = JSON.stringify({ document: doc })
+    const bodyBytes = new TextEncoder().encode(body).byteLength
     await fetch(`${syncUrl}/api/mcp/document`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ document: doc }),
+      headers: {
+        'Content-Type': 'application/json',
+        'x-openpencil-client-id': 'mcp-server:live-canvas',
+        'x-openpencil-body-bytes': String(bodyBytes),
+      },
+      body,
     })
   } catch {
     // Network error — Electron might have quit between check and request

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "openpencil-mcp": "out/mcp-server.cjs"
   },
   "scripts": {
-    "dev": "cd apps/web && bun --bun vite dev --port 3000",
+    "dev": "bun run apps/web/dev.ts",
     "build": "cd apps/web && bun --bun vite build",
     "preview": "cd apps/web && bun --bun vite preview",
     "test": "cd apps/web && bun --bun vitest run --passWithNoTests",

--- a/scripts/loopback-no-proxy.test.ts
+++ b/scripts/loopback-no-proxy.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  ensureLoopbackNoProxy,
+  mergeLoopbackNoProxyValue,
+  withLoopbackNoProxy,
+} from './loopback-no-proxy'
+
+describe('loopback no_proxy helpers', () => {
+  test('mergeLoopbackNoProxyValue 保留已有条目并补齐本地回环地址', () => {
+    expect(mergeLoopbackNoProxyValue('example.com,localhost')).toBe(
+      'example.com,localhost,127.0.0.1,::1',
+    )
+  })
+
+  test('withLoopbackNoProxy 同时写回 NO_PROXY 和 no_proxy', () => {
+    const next = withLoopbackNoProxy({
+      http_proxy: 'http://127.0.0.1:7897',
+      NO_PROXY: 'example.com',
+    })
+
+    expect(next.NO_PROXY).toBe('example.com,127.0.0.1,localhost,::1')
+    expect(next.no_proxy).toBe(next.NO_PROXY)
+  })
+
+  test('ensureLoopbackNoProxy 原地更新现有环境对象', () => {
+    const env: NodeJS.ProcessEnv = { no_proxy: 'localhost,example.com' }
+
+    ensureLoopbackNoProxy(env)
+
+    expect(env.NO_PROXY).toBe('localhost,example.com,127.0.0.1,::1')
+    expect(env.no_proxy).toBe(env.NO_PROXY)
+  })
+})

--- a/scripts/loopback-no-proxy.ts
+++ b/scripts/loopback-no-proxy.ts
@@ -1,0 +1,54 @@
+/**
+ * 本地回环地址必须直连。
+ *
+ * 在带代理环境里, 如果 dev server 或 Electron 子进程没有正确补齐
+ * NO_PROXY/no_proxy, 那么发往 localhost 的请求可能会被错误转发给代理。
+ * 对 OpenPencil 来说, 这会直接打断本地 SSR 和 Electron dev 的加载链路。
+ */
+
+export const loopbackBypassHosts = ['127.0.0.1', 'localhost', '::1'] as const
+
+function splitNoProxy(value?: string): string[] {
+  if (!value) return []
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+
+/**
+ * 合并已有的 NO_PROXY/no_proxy, 并确保本地回环地址永远在绕过名单里。
+ */
+export function mergeLoopbackNoProxyValue(value?: string): string {
+  const entries = new Set(splitNoProxy(value))
+  for (const host of loopbackBypassHosts) {
+    entries.add(host)
+  }
+  return Array.from(entries).join(',')
+}
+
+/**
+ * 返回一个带本地回环绕过规则的新环境变量对象。
+ *
+ * 这里同时写回 NO_PROXY 和 no_proxy。
+ * 这样可以兼容不同工具对大小写环境变量的读取习惯。
+ */
+export function withLoopbackNoProxy(
+  env: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const merged = mergeLoopbackNoProxyValue(env.NO_PROXY ?? env.no_proxy)
+  return {
+    ...env,
+    NO_PROXY: merged,
+    no_proxy: merged,
+  }
+}
+
+/**
+ * 原地补齐当前进程的本地回环绕过规则。
+ */
+export function ensureLoopbackNoProxy(env: NodeJS.ProcessEnv): void {
+  const merged = mergeLoopbackNoProxyValue(env.NO_PROXY ?? env.no_proxy)
+  env.NO_PROXY = merged
+  env.no_proxy = merged
+}


### PR DESCRIPTION
## Summary

This PR stabilizes the Electron dev workflow and reduces renderer-side live sync noise.

### What changed

- fix Electron dev startup probing by switching the localhost readiness check to direct loopback port probing
- ensure the dev workflow consistently bypasses proxy interference for loopback traffic
- reduce `/api/mcp/document` sync noise by:
  - adding request source and body-size diagnostics
  - treating client-closed requests as a non-fatal sync condition
  - avoiding unnecessary broadcast serialization when there are no recipients
  - narrowing renderer-side sync triggers to actual document / dirty-state changes
  - skipping oversized renderer live-sync payloads instead of repeatedly flooding the dev server
- fix bitmap-backed shape dragging by avoiding automatic parent selection for nodes with image visuals and by keeping drag-time clip rects in sync

## Why

There were several dev-mode issues that compounded together:

- Electron dev could report a localhost timeout even after Vite was already ready
- renderer live sync could repeatedly send very large payloads and generate noisy closed-socket errors
- imported bitmap-backed shapes could temporarily disappear during dragging unless the interaction path changed

This PR keeps the editor behavior stable first, while preserving enough diagnostics for future follow-up if a deeper sync redesign is needed.

## Validation

- `bun run electron:dev`
- `bunx tsc -p apps/web/tsconfig.json --noEmit`
- verified the Electron dev chain reaches:
  - `Vite is ready`
  - Electron compile
  - Electron launch
- verified bitmap-backed shapes no longer require a double-click path to drag correctly
