### PR TITLE
feat(ai): upgrade MiniMax default model to M3

### DIFF
--- a/apps/web/src/components/shared/model-selector.tsx
+++ b/apps/web/src/components/shared/model-selector.tsx
@@ -22,12 +22,9 @@ export const BUILTIN_MODEL_LISTS: Partial<
     { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash' },
   ],
   minimax: [
+    { id: 'MiniMax-M3', name: 'MiniMax M3' },
     { id: 'MiniMax-M2.7', name: 'MiniMax M2.7' },
     { id: 'MiniMax-M2.7-highspeed', name: 'MiniMax M2.7 Highspeed' },
-    { id: 'MiniMax-M2.5', name: 'MiniMax M2.5' },
-    { id: 'MiniMax-M2.5-highspeed', name: 'MiniMax M2.5 Highspeed' },
-    { id: 'MiniMax-M2.1', name: 'MiniMax M2.1' },
-    { id: 'MiniMax-M1', name: 'MiniMax M1' },
   ],
   'glm-coding': [
     { id: 'glm-5', name: 'GLM-5' },

--- a/apps/web/src/lib/builtin-provider-presets.ts
+++ b/apps/web/src/lib/builtin-provider-presets.ts
@@ -67,7 +67,7 @@ export const BUILTIN_PROVIDER_PRESETS: Record<BuiltinProviderPreset, BuiltinPres
     altRegions: { cn: 'https://api.minimaxi.com/v1', global: 'https://api.minimax.io/v1' },
     altType: 'openai-compat',
     placeholder: 'eyJ...',
-    modelPlaceholder: 'MiniMax-M2.7',
+    modelPlaceholder: 'MiniMax-M3',
     regions: {
       cn: { baseURL: 'https://api.minimaxi.com/anthropic' },
       global: { baseURL: 'https://api.minimax.io/anthropic' },


### PR DESCRIPTION
## Summary
Upgrade the built-in MiniMax provider configuration to use `MiniMax-M3` as the default model.

## Changes
- Add `MiniMax-M3` to the MiniMax model selection list and set it as the default (first entry)
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Remove older models (`MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2.1`, `MiniMax-M1`)
- Update `modelPlaceholder` for the minimax preset in `builtin-provider-presets.ts` to `MiniMax-M3`

## Why
`MiniMax-M3` is the latest MiniMax model. It offers a 512K context window, up to 128K output, and supports image input on both OpenAI-compatible and Anthropic-compatible endpoints. Promoting it to default keeps OpenPencil's built-in MiniMax preset aligned with the latest recommended model while still letting users fall back to the M2.7 family.

## Files touched
- `apps/web/src/components/shared/model-selector.tsx`
- `apps/web/src/lib/builtin-provider-presets.ts`

## Testing
- The change is limited to the static model list and the input placeholder; no behavioral logic was modified.
- Existing tests in `apps/web/src/lib/__tests__/builtin-provider-presets.test.ts` only assert URL/preset canonicalization (using `MiniMax-M2.7` as test data), so they continue to pass.