### PR TITLE
fix(editor): prevent hover border from overriding focus ring across all inputs

### DIFF
--- a/apps/web/src/components/panels/icon-section.tsx
+++ b/apps/web/src/components/panels/icon-section.tsx
@@ -225,7 +225,7 @@ export default function IconSection({ node, onUpdate }: IconSectionProps) {
         <select
           value={displayCollection}
           onChange={(e) => handleLibraryChange(e.target.value)}
-          className="w-full h-7 bg-secondary text-foreground text-[11px] px-2 rounded border border-transparent hover:border-input focus:border-ring focus:outline-none cursor-pointer transition-colors appearance-none"
+          className="w-full h-7 bg-secondary text-foreground text-[11px] px-2 rounded border border-transparent hover:border-input focus:border-ring focus:hover:border-ring focus:outline-none cursor-pointer transition-colors appearance-none"
         >
           {!POPULAR_COLLECTIONS.some((c) => c.id === displayCollection) && displayCollection && (
             <option value={displayCollection}>{displayCollection}</option>

--- a/apps/web/src/components/panels/variable-row.tsx
+++ b/apps/web/src/components/panels/variable-row.tsx
@@ -165,7 +165,7 @@ export default function VariableRow({
               type="text"
               value={String(getValueForTheme(tv))}
               onChange={(e) => setValueForTheme(tv, e.target.value)}
-              className="flex-1 max-w-[180px] bg-secondary/50 text-foreground text-[13px] px-2 py-1 rounded-lg border border-transparent hover:border-input focus:border-ring focus:outline-none font-mono min-w-0"
+              className="flex-1 max-w-[180px] bg-secondary/50 text-foreground text-[13px] px-2 py-1 rounded-lg border border-transparent hover:border-input focus:border-ring focus:hover:border-ring focus:outline-none font-mono min-w-0"
             />
           )}
         </div>

--- a/apps/web/src/components/shared/color-picker.tsx
+++ b/apps/web/src/components/shared/color-picker.tsx
@@ -52,7 +52,7 @@ export default function ColorPicker({ value, onChange, label, className }: Color
   return (
     <div className={cn('flex items-center gap-1.5', className)}>
       {label && <span className="text-[10px] text-muted-foreground shrink-0">{label}</span>}
-      <div className="flex items-center h-6 bg-secondary rounded border border-transparent hover:border-input focus-within:border-ring transition-colors flex-1">
+      <div className="flex items-center h-6 bg-secondary rounded border border-transparent hover:border-input focus-within:border-ring focus-within:hover:border-ring transition-colors flex-1">
         <div className="pl-1 shrink-0">
           <input
             type="color"

--- a/apps/web/src/components/shared/number-input.tsx
+++ b/apps/web/src/components/shared/number-input.tsx
@@ -146,7 +146,7 @@ export default function NumberInput({
     <div
       className={cn(
         'flex items-center h-6 bg-secondary rounded border border-transparent',
-        'hover:border-input focus-within:border-ring transition-colors',
+        'hover:border-input focus-within:border-ring focus-within:hover:border-ring transition-colors',
         className,
       )}
       onMouseDown={handleMouseDown}

--- a/packages/pen-react/src/components/color-picker.tsx
+++ b/packages/pen-react/src/components/color-picker.tsx
@@ -51,7 +51,7 @@ export function ColorPicker({ value, onChange, label, className }: ColorPickerPr
   return (
     <div className={cn('flex items-center gap-1.5', className)}>
       {label && <span className="text-[10px] text-muted-foreground shrink-0">{label}</span>}
-      <div className="flex items-center h-6 bg-secondary rounded border border-transparent hover:border-input focus-within:border-ring transition-colors flex-1">
+      <div className="flex items-center h-6 bg-secondary rounded border border-transparent hover:border-input focus-within:border-ring focus-within:hover:border-ring transition-colors flex-1">
         <div className="pl-1 shrink-0">
           <input
             type="color"

--- a/packages/pen-react/src/components/number-input.tsx
+++ b/packages/pen-react/src/components/number-input.tsx
@@ -104,7 +104,7 @@ export function NumberInput({
     <div
       className={cn(
         'flex items-center h-6 bg-secondary rounded border border-transparent',
-        'hover:border-input focus-within:border-ring transition-colors',
+        'hover:border-input focus-within:border-ring focus-within:hover:border-ring transition-colors',
         className,
       )}
       onMouseDown={handleMouseDown}

--- a/packages/pen-react/src/components/sections/icon-section.tsx
+++ b/packages/pen-react/src/components/sections/icon-section.tsx
@@ -104,7 +104,7 @@ export function IconSection({ node, onUpdate }: IconSectionProps) {
         <select
           value={displayCollection}
           onChange={(e) => handleLibraryChange(e.target.value)}
-          className="w-full h-7 bg-secondary text-foreground text-[11px] px-2 rounded border border-transparent hover:border-input focus:border-ring focus:outline-none cursor-pointer transition-colors appearance-none"
+          className="w-full h-7 bg-secondary text-foreground text-[11px] px-2 rounded border border-transparent hover:border-input focus:border-ring focus:hover:border-ring focus:outline-none cursor-pointer transition-colors appearance-none"
         >
           {!POPULAR_COLLECTIONS.some((c) => c.id === displayCollection) && displayCollection && (
             <option value={displayCollection}>{displayCollection}</option>


### PR DESCRIPTION
## Summary

When hovering over a focused input, the hover border color (`border-input`) overrides the focus ring (`border-ring`), making it hard to tell the field is active.

## Changes

Apply `focus-within:hover:border-ring` / `focus:hover:border-ring` to all affected components:

- `apps/web`: `number-input`, `color-picker`, `icon-section`, `variable-row`
- `packages/pen-react`: `number-input`, `color-picker`, `icon-section`

## Related Issues

N/A

## Type

- [x] `fix` — Bug fix

## Checklist

- [x] `npx tsc --noEmit` passes
- [x] `bun --bun run test` passes
- [x] No unrelated changes included
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Root cause

`hover:border-input` and `focus-within:border-ring` / `focus:border-ring` both compile to CSS with specificity (0,2,0). When both pseudo-classes are active simultaneously, the rule declared later in Tailwind's generated stylesheet wins — which is the hover rule. Adding the combined variant at specificity (0,3,0) explicitly keeps the focus ring visible while hovering.