### PR TITLE
fix(ai): blur chat input when agent settings open to prevent paste misrouting

### DIFF
--- a/crates/op-host-desktop/src/keyboard_input.rs
+++ b/crates/op-host-desktop/src/keyboard_input.rs
@@ -382,6 +382,16 @@ impl DesktopApp {
     /// pastes Figma clipboard HTML or the document node clipboard onto
     /// the canvas. `pub(crate)` for the Edit-menu path.
     pub(crate) fn handle_cmd_paste(&mut self) -> bool {
+        // Non-chat text inputs (settings, git, rename, etc.) are
+        // checked first so that opening a modal (e.g. agent settings
+        // via Cmd+,) while the chat input is focused routes the paste
+        // to the modal's field instead of the chat.
+        if self.host.input_active_pub() && !self.host.editor_state().chat.focused {
+            if let Some(text) = crate::clipboard::get_text() {
+                self.host.apply_input_paste(&text);
+            }
+            return true;
+        }
         if self.host.editor_state().chat.focused {
             // Clipboard image data wins over text when pasting into the
             // chat input; the paste is consumed either way.
@@ -389,12 +399,6 @@ impl DesktopApp {
                 if let Some(text) = crate::clipboard::get_text() {
                     self.host.chat_input_paste(&text);
                 }
-            }
-            return true;
-        }
-        if self.host.input_active_pub() {
-            if let Some(text) = crate::clipboard::get_text() {
-                self.host.apply_input_paste(&text);
             }
             return true;
         }

--- a/crates/op-host-native/src/widget_host/input.rs
+++ b/crates/op-host-native/src/widget_host/input.rs
@@ -45,7 +45,8 @@ impl WidgetHostNative {
             || self.editor_state.editor_ui.effect_param_focus.is_some()
             || self.editor_state.color_picker_hex_focused()
             || self.editor_state.color_picker_rgb_focused()
-            || self.editor_state.editor_ui.agent_settings.focus.is_some()
+            || (self.editor_state.editor_ui.agent_settings_open
+                && self.editor_state.editor_ui.agent_settings.focus.is_some())
             || self.editor_state.editor_ui.icon_picker.open
             || self.editor_state.editor_ui.chat_model_picker.open
             || self.editor_state.editor_ui.component_browser_open

--- a/crates/op-host-native/src/widget_host/press.rs
+++ b/crates/op-host-native/src/widget_host/press.rs
@@ -456,6 +456,7 @@ impl WidgetHostNative {
                 }
                 TopBarHit::OpenAgentSettings => {
                     self.editor_state.editor_ui.agent_settings_open = true;
+                    self.editor_state.chat.blur_input(self.now_ms);
                     self.mark_dirty();
                     return true;
                 }

--- a/crates/op-host-native/src/widget_host/shortcuts.rs
+++ b/crates/op-host-native/src/widget_host/shortcuts.rs
@@ -379,7 +379,9 @@ impl WidgetHostNative {
         self.commit_variable_row_focus_if_any();
         self.editor_state.editor_ui.agent_settings_open =
             !self.editor_state.editor_ui.agent_settings_open;
-        if !self.editor_state.editor_ui.agent_settings_open {
+        if self.editor_state.editor_ui.agent_settings_open {
+            self.editor_state.chat.blur_input(self.now_ms);
+        } else {
             self.editor_state.editor_ui.agent_settings_drag = None;
         }
         self.mark_dirty();

--- a/crates/op-host-web/src/widget_host/keyboard_text_inputs.rs
+++ b/crates/op-host-web/src/widget_host/keyboard_text_inputs.rs
@@ -28,7 +28,8 @@ impl WidgetHost {
             // instead of typing into the preset name).
             || self.editor_state.editor_ui.preset_name_input_active()
             || self.variables_search_active()
-            || self.editor_state.editor_ui.agent_settings.focus.is_some()
+            || (self.editor_state.editor_ui.agent_settings_open
+                && self.editor_state.editor_ui.agent_settings.focus.is_some())
             || self.editor_state.editor_ui.icon_picker.open
             || self.editor_state.editor_ui.chat_model_picker.open
             || self.editor_state.editor_ui.component_browser_open

--- a/crates/op-host-web/src/widget_host/press.rs
+++ b/crates/op-host-web/src/widget_host/press.rs
@@ -359,6 +359,7 @@ impl WidgetHost {
                 }
                 TopBarHit::OpenAgentSettings => {
                     self.editor_state.editor_ui.agent_settings_open = true;
+                    self.editor_state.chat.blur_input(self.now_ms);
                 }
                 TopBarHit::ToggleFileMenu => {
                     self.editor_state.editor_ui.file_menu_open ^= true;


### PR DESCRIPTION
## Summary

Fixes paste misrouting: with the AI chat input focused, opening the agent settings panel to paste an API key sent the pasted text into the chat input instead of the settings field.

## Root cause

Three compounding issues:

1. **Opening agent settings never blurred the chat input.** Neither the top-bar click (`TopBarHit::OpenAgentSettings`) nor the keyboard shortcut cleared `chat.focused`, so the chat input silently kept keyboard focus behind the modal.
2. **`handle_cmd_paste` (desktop) checked `chat.focused` first.** Because of (1) that branch always won, so ⌘V was consumed by the chat input even when an agent-settings field was the visually focused input.
3. **Stale `agent_settings.focus` claimed the keyboard.** `input_active()` treated `agent_settings.focus.is_some()` as an active input without checking whether the panel was actually open, so focus state left over from a previously closed panel could swallow key events.

## Fix

Applied symmetrically to **both hosts — native/desktop (`op-host-native`, `op-host-desktop`) and web (`op-host-web`)**:

- Call `chat.blur_input()` whenever the agent settings panel opens (top-bar click and shortcut paths), so `chat.focused` becomes false before the user interacts with the panel.
- Guard the `agent_settings.focus` check in `input_active()` with `agent_settings_open`, eliminating the stale-focus path.
- Reorder desktop `handle_cmd_paste` to route to non-chat text inputs first (settings, git, rename, …), with an explicit `!chat.focused` guard as defense in depth.

## Test Plan

- [x] `cargo check -p op-host-desktop -p op-host-native` — clean
- [x] `cargo check --target wasm32-unknown-unknown -p op-host-web --no-default-features --features web` — clean
- [ ] Manual: focus chat input → open agent settings (click gear / shortcut) → click API-key field → ⌘V pastes into the settings field, not the chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)
