### PR TITLE
fix(desktop): round window corners and add border on Windows

### DIFF
--- a/crates/op-host-desktop/src/app_handler.rs
+++ b/crates/op-host-desktop/src/app_handler.rs
@@ -104,6 +104,13 @@ impl ApplicationHandler<DesktopEvent> for DesktopApp {
         {
             attrs = attrs.with_decorations(false);
         }
+        #[cfg(target_os = "windows")]
+        {
+            use winit::platform::windows::{Color, CornerPreference, WindowAttributesExtWindows};
+            attrs = attrs
+                .with_corner_preference(CornerPreference::Round)
+                .with_border_color(Some(Color::from_rgb(0x31, 0x31, 0x31)));
+        }
         // Restore the window geometry from the previous session
         // (position / size / maximized). A missing or stale file
         // leaves the default attrs untouched.


### PR DESCRIPTION
## Summary
- `with_decorations(false)` strips the native frame entirely on Windows, so DWM was painting the borderless window as a flat rectangle with sharp corners and no border, unlike the intended Electron-style hidden-titlebar look already working on macOS.
- Opt back into Windows 11's rounded-corner treatment and a hairline border (matching the dark chrome's `#313131`) via casement's `WindowAttributesExtWindows::with_corner_preference` / `with_border_color`, applied through `DwmSetWindowAttribute` at window creation.
- Linux (X11/Wayland) has the same underlying gap, but casement exposes no equivalent per-window API there — left as a follow-up since it would require self-drawn rounded corners (compositor-dependent), a larger change.

## Test plan
- [x] `cargo check -p op-host-desktop`
- [x] Manual: run `cargo run -p openpencil-desktop --release` on Windows 11 and confirm the window has rounded corners + a visible hairline border