### PR TITLE
feat(ai): add MiniMax M3 image input

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,13 @@ docker run -p 3100:3100 openpencil-web-rust
 | **GitHub Copilot**          | `copilot login` then connect in Agent Settings (`Cmd+,`)                                          |
 | **Gemini CLI**              | Connect in Agent Settings (`Cmd+,`)                                                               |
 
+The MiniMax preset defaults to `MiniMax-M3` and sends attached images as native multimodal content. The model and Base URL fields remain editable, so existing `MiniMax-M2.7` profiles continue to work and either regional endpoint can be selected:
+
+| Region | OpenAI-compatible Base URL | Anthropic-compatible Base URL |
+| ------ | -------------------------- | ----------------------------- |
+| Global | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` |
+| China | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` |
+
 **Model Capability Profiles** — automatically adapts prompts, thinking mode, and timeouts per model tier. Full-tier models (Claude) get complete prompts; standard-tier (GPT-4o, Gemini, DeepSeek) disable thinking; basic-tier (MiniMax, Qwen, Llama, Mistral) get simplified nested-JSON prompts for maximum reliability.
 
 **i18n** — Full interface localization in 15 languages: English, 简体中文, 繁體中文, 日本語, 한국어, Français, Español, Deutsch, Português, Русский, हिन्दी, Türkçe, ไทย, Tiếng Việt, Bahasa Indonesia.

--- a/crates/op-editor-core/src/agent_settings_builtin_presets.rs
+++ b/crates/op-editor-core/src/agent_settings_builtin_presets.rs
@@ -150,7 +150,7 @@ pub const BUILTIN_AGENT_PRESETS: [BuiltinAgentPreset; 19] = [
         key: BuiltinAgentPresetKey::MiniMax,
         display_name: "MiniMax",
         kind: BuiltinAgentKind::Anthropic,
-        model: "MiniMax-M2.7",
+        model: "MiniMax-M3",
         base_url: "https://api.minimaxi.com/anthropic",
         alt_kind: Some(BuiltinAgentKind::OpenAiCompat),
         alt_base_url: Some("https://api.minimaxi.com/v1"),

--- a/crates/op-editor-core/src/tests_agent_settings_draft.rs
+++ b/crates/op-editor-core/src/tests_agent_settings_draft.rs
@@ -94,7 +94,7 @@ fn builtin_agent_draft_can_select_ts_builtin_provider_preset() {
     assert_eq!(draft.display_name, "MiniMax");
     assert_eq!(draft.kind, BuiltinAgentKind::Anthropic);
     assert_eq!(draft.base_url, "https://api.minimaxi.com/anthropic");
-    assert_eq!(draft.model, "MiniMax-M2.7");
+    assert_eq!(draft.model, "MiniMax-M3");
     assert_eq!(draft.api_key, "sk-test");
 }
 

--- a/crates/op-host-native/src/widget_host/agent_settings_tests.rs
+++ b/crates/op-host-native/src/widget_host/agent_settings_tests.rs
@@ -301,7 +301,7 @@ fn builtin_provider_menu_selects_ts_preset_for_draft() {
         .expect("draft remains open");
     assert_eq!(draft.preset, BuiltinAgentPresetKey::MiniMax);
     assert_eq!(draft.display_name, "MiniMax");
-    assert_eq!(draft.model, "MiniMax-M2.7");
+    assert_eq!(draft.model, "MiniMax-M3");
     assert_eq!(draft.base_url, "https://api.minimaxi.com/anthropic");
 }
 

--- a/crates/op-host-services/src/chat_agent_loop.rs
+++ b/crates/op-host-services/src/chat_agent_loop.rs
@@ -39,7 +39,7 @@ pub struct AgentLoopConfig {
     pub model: String,
     pub system_prompt: String,
     pub history: Vec<(ChatHistoryRole, String)>,
-    pub user_prompt: String,
+    pub user_prompt: Value,
     pub max_output_tokens: u32,
     pub tools: Vec<ChatToolDef>,
     pub executor: Arc<dyn ChatToolExecutor>,

--- a/crates/op-host-services/src/chat_attachment.rs
+++ b/crates/op-host-services/src/chat_attachment.rs
@@ -21,6 +21,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use base64::Engine;
 use op_ai::chat_provider::{ChatDelta, StopReason};
 use op_editor_core::chat::{ChatAttachment, ThinkingMode};
+use serde_json::{json, Value};
 
 /// Per-process counter making each turn's temp directory unique.
 static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
@@ -29,6 +30,49 @@ static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
 /// providers add their own wrapper).
 pub fn attachment_to_base64(att: &ChatAttachment) -> String {
     base64::engine::general_purpose::STANDARD.encode(&att.data)
+}
+
+/// Build Anthropic user content with native base64 image blocks.
+pub fn anthropic_user_content(prompt: &str, images: &[ChatAttachment]) -> Value {
+    if images.is_empty() {
+        return Value::String(prompt.to_string());
+    }
+    let mut content = Vec::with_capacity(images.len() + 1);
+    if !prompt.is_empty() {
+        content.push(json!({ "type": "text", "text": prompt }));
+    }
+    content.extend(images.iter().map(|image| {
+        json!({
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": image.media_type,
+                "data": attachment_to_base64(image),
+            },
+        })
+    }));
+    Value::Array(content)
+}
+
+/// Build OpenAI-compatible user content with native data-URL images.
+pub fn openai_user_content(prompt: &str, images: &[ChatAttachment]) -> Value {
+    if images.is_empty() {
+        return Value::String(prompt.to_string());
+    }
+    let mut content = Vec::with_capacity(images.len() + 1);
+    if !prompt.is_empty() {
+        content.push(json!({ "type": "text", "text": prompt }));
+    }
+    content.extend(images.iter().map(|image| {
+        let data = attachment_to_base64(image);
+        json!({
+            "type": "image_url",
+            "image_url": {
+                "url": format!("data:{};base64,{data}", image.media_type),
+            },
+        })
+    }));
+    Value::Array(content)
 }
 
 /// Best-effort MIME type from a file path's extension. Falls back to

--- a/crates/op-host-services/src/chat_builtin_http.rs
+++ b/crates/op-host-services/src/chat_builtin_http.rs
@@ -131,25 +131,36 @@ impl ChatProvider for ConfiguredBuiltinProvider {
     }
 
     fn send(&self, request: ChatRequest) -> Box<dyn Iterator<Item = ChatDelta> + Send> {
+        let ChatRequest {
+            system_prompt,
+            user_message,
+            history,
+            max_output_tokens,
+            thinking,
+            effort,
+            attachments,
+            ..
+        } = request;
+        let native_images_enabled = supports_native_image_input(&self.model);
+        let (native_images, fallback_attachments): (Vec<_>, Vec<_>) = attachments
+            .into_iter()
+            .partition(|attachment| native_images_enabled && attachment.is_image());
         let (mut prompt, guard) = match crate::chat_attachment::prompt_with_attachments(
-            &request.user_message,
-            &request.attachments,
+            &user_message,
+            &fallback_attachments,
         ) {
             Ok(pair) => pair,
             Err(e) => return crate::chat_attachment::attachment_error_turn(e),
         };
         let mut directive = String::new();
-        if let Some(d) = crate::chat_attachment::thinking_directive(request.thinking) {
+        if let Some(d) = crate::chat_attachment::thinking_directive(thinking) {
             directive.push_str(d);
         }
-        if request.effort != EffortLevel::Low {
+        if effort != EffortLevel::Low {
             if !directive.is_empty() {
                 directive.push(' ');
             }
-            directive.push_str(&format!(
-                "Apply {} reasoning effort.",
-                request.effort.as_str()
-            ));
+            directive.push_str(&format!("Apply {} reasoning effort.", effort.as_str()));
         }
         if !directive.is_empty() {
             prompt = format!("{directive}\n\n{prompt}");
@@ -158,23 +169,30 @@ impl ChatProvider for ConfiguredBuiltinProvider {
         // resolves the skill corpus; only fall back to the in-prompt
         // preamble when the caller sent no system prompt — otherwise
         // the skills would ride the wire twice.
-        if request.system_prompt.trim().is_empty() {
-            let preamble = resolved_skill_preamble(&request.user_message);
+        if system_prompt.trim().is_empty() {
+            let preamble = resolved_skill_preamble(&user_message);
             if !preamble.is_empty() {
                 prompt = format!("{preamble}\n\n---\n\n{prompt}");
             }
         }
 
+        let user_content = match self.kind {
+            BuiltinAgentKind::Anthropic => {
+                crate::chat_attachment::anthropic_user_content(&prompt, &native_images)
+            }
+            BuiltinAgentKind::OpenAiCompat => {
+                crate::chat_attachment::openai_user_content(&prompt, &native_images)
+            }
+        };
+
         let provider = self.clone();
-        let system_prompt = request.system_prompt;
-        let history = request.history;
-        let max_output_tokens = request.max_output_tokens.max(1);
+        let max_output_tokens = max_output_tokens.max(1);
         // Only force MiniMax thinking off when the CALLER asked for it
         // (the orchestrator sets `Disabled`; normal chat defaults to
         // `Adaptive` and must keep M3's reasoning). Codex review caught
         // an earlier version disabling thinking unconditionally for all
         // MiniMax chat.
-        let disable_thinking = request.thinking == ThinkingMode::Disabled;
+        let disable_thinking = thinking == ThinkingMode::Disabled;
         let (tx, rx) = mpsc::channel::<ChatDelta>(64);
         shared_runtime().spawn(async move {
             let _guard = guard;
@@ -193,7 +211,7 @@ impl ChatProvider for ConfiguredBuiltinProvider {
                     model: provider.model.clone(),
                     system_prompt,
                     history,
-                    user_prompt: prompt,
+                    user_prompt: user_content,
                     max_output_tokens,
                     tools: provider.tools.clone(),
                     executor,
@@ -216,7 +234,7 @@ impl ChatProvider for ConfiguredBuiltinProvider {
                             provider,
                             system_prompt,
                             history,
-                            prompt,
+                            user_content,
                             max_output_tokens,
                             &tx,
                         )
@@ -227,7 +245,7 @@ impl ChatProvider for ConfiguredBuiltinProvider {
                             provider,
                             system_prompt,
                             history,
-                            prompt,
+                            user_content,
                             max_output_tokens,
                             disable_thinking,
                             &tx,
@@ -264,6 +282,10 @@ impl ChatProvider for ConfiguredBuiltinProvider {
 pub(crate) fn is_minimax_model(model: &str) -> bool {
     let m = model.to_ascii_lowercase();
     m.starts_with("minimax") || m.starts_with("abab")
+}
+
+pub(crate) fn supports_native_image_input(model: &str) -> bool {
+    model.trim().eq_ignore_ascii_case("MiniMax-M3")
 }
 
 /// GLM-4.5+/GLM-5.x（智谱 / 方舟 coding plan）同为推理模型：reasoning 走
@@ -369,7 +391,7 @@ async fn run_openai_chat(
     provider: ConfiguredBuiltinProvider,
     system_prompt: String,
     history: Vec<(ChatHistoryRole, String)>,
-    prompt: String,
+    prompt: Value,
     max_output_tokens: u32,
     disable_thinking: bool,
     tx: &mpsc::Sender<ChatDelta>,
@@ -438,7 +460,7 @@ async fn run_anthropic_chat(
     provider: ConfiguredBuiltinProvider,
     system_prompt: String,
     history: Vec<(ChatHistoryRole, String)>,
-    prompt: String,
+    prompt: Value,
     max_output_tokens: u32,
     tx: &mpsc::Sender<ChatDelta>,
 ) -> Result<bool, String> {

--- a/crates/op-host-services/src/chat_minimax_image_tests.rs
+++ b/crates/op-host-services/src/chat_minimax_image_tests.rs
@@ -1,0 +1,197 @@
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
+
+use op_ai::chat_provider::{
+    ChatAttachment, ChatProvider, ChatRequest, ChatToolExecutor, ChatToolResult,
+};
+use op_editor_core::{BuiltinAgentConfig, BuiltinAgentKind, BuiltinAgentPresetKey};
+use serde_json::Value;
+
+use crate::chat_builtin_http::{supports_native_image_input, ConfiguredBuiltinProvider};
+
+struct NoopExecutor;
+
+impl ChatToolExecutor for NoopExecutor {
+    fn execute(&self, _name: &str, _args_json: &str) -> ChatToolResult {
+        panic!("the capture response must not request a tool")
+    }
+}
+
+fn read_request(stream: &mut TcpStream) -> String {
+    let mut buf = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    loop {
+        let n = stream.read(&mut chunk).expect("read request");
+        if n == 0 {
+            break;
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        let Some(header_end) = buf.windows(4).position(|window| window == b"\r\n\r\n") else {
+            continue;
+        };
+        let headers = String::from_utf8_lossy(&buf[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (key, value) = line.split_once(':')?;
+                key.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+        if buf.len() >= header_end + 4 + content_length {
+            break;
+        }
+    }
+    String::from_utf8(buf).expect("request is UTF-8")
+}
+
+fn capture_request(
+    kind: BuiltinAgentKind,
+    base_path: &str,
+    response_body: &'static str,
+    use_agent_loop: bool,
+) -> (String, Value) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind capture server");
+    let addr = listener.local_addr().expect("capture server address");
+    let (request_tx, request_rx) = mpsc::channel();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept request");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .expect("set read timeout");
+        request_tx
+            .send(read_request(&mut stream))
+            .expect("send captured request");
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            response_body.len(),
+            response_body,
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write response");
+    });
+
+    let provider = ConfiguredBuiltinProvider::from_builtin_agent(&BuiltinAgentConfig {
+        id: "builtin-minimax".into(),
+        preset: BuiltinAgentPresetKey::MiniMax,
+        display_name: "MiniMax".into(),
+        kind,
+        api_key: "test-key".into(),
+        model: "MiniMax-M3".into(),
+        base_url: format!("http://{addr}{base_path}"),
+        enabled: true,
+    })
+    .expect("ready provider");
+    let provider = if use_agent_loop {
+        provider.with_canvas_tools(Vec::new(), Arc::new(NoopExecutor))
+    } else {
+        provider
+    };
+    let _deltas: Vec<_> = provider
+        .send(ChatRequest {
+            user_message: "Inspect this reference image.".into(),
+            max_output_tokens: 64,
+            attachments: vec![ChatAttachment {
+                name: "reference.png".into(),
+                media_type: "image/png".into(),
+                data: b"png".to_vec(),
+            }],
+            ..Default::default()
+        })
+        .collect();
+    server.join().expect("capture server exits");
+
+    let request = request_rx.recv().expect("captured request");
+    let (headers, body) = request
+        .split_once("\r\n\r\n")
+        .expect("request has headers and body");
+    let request_line = headers.lines().next().expect("request line").to_string();
+    let body = serde_json::from_str(body).expect("request body is JSON");
+    (request_line, body)
+}
+
+#[test]
+fn only_minimax_m3_enables_native_image_input() {
+    assert!(supports_native_image_input("MiniMax-M3"));
+    assert!(!supports_native_image_input("MiniMax-M2.7"));
+}
+
+#[test]
+fn openai_compatible_request_appends_path_and_sends_image_data_url() {
+    let (request_line, body) = capture_request(
+        BuiltinAgentKind::OpenAiCompat,
+        "/v1",
+        "data: [DONE]\n\n",
+        false,
+    );
+    assert_eq!(request_line, "POST /v1/chat/completions HTTP/1.1");
+    assert_eq!(
+        body.pointer("/messages/0/content/1/type")
+            .and_then(Value::as_str),
+        Some("image_url")
+    );
+    assert_eq!(
+        body.pointer("/messages/0/content/1/image_url/url")
+            .and_then(Value::as_str),
+        Some("data:image/png;base64,cG5n")
+    );
+}
+
+#[test]
+fn anthropic_request_appends_path_and_sends_image_block() {
+    let (request_line, body) = capture_request(
+        BuiltinAgentKind::Anthropic,
+        "/anthropic",
+        "data: {\"type\":\"message_stop\"}\n\n",
+        false,
+    );
+    assert_eq!(request_line, "POST /anthropic/v1/messages HTTP/1.1");
+    assert_eq!(
+        body.pointer("/messages/0/content/1/type")
+            .and_then(Value::as_str),
+        Some("image")
+    );
+    assert_eq!(
+        body.pointer("/messages/0/content/1/source/data")
+            .and_then(Value::as_str),
+        Some("cG5n")
+    );
+}
+
+#[test]
+fn agent_loops_preserve_native_image_content_for_both_protocols() {
+    let (openai_request_line, openai_body) = capture_request(
+        BuiltinAgentKind::OpenAiCompat,
+        "/v1",
+        "data: [DONE]\n\n",
+        true,
+    );
+    assert_eq!(openai_request_line, "POST /v1/chat/completions HTTP/1.1");
+    assert_eq!(
+        openai_body
+            .pointer("/messages/0/content/1/type")
+            .and_then(Value::as_str),
+        Some("image_url")
+    );
+
+    let (anthropic_request_line, anthropic_body) = capture_request(
+        BuiltinAgentKind::Anthropic,
+        "/anthropic",
+        "data: {\"type\":\"message_stop\"}\n\n",
+        true,
+    );
+    assert_eq!(
+        anthropic_request_line,
+        "POST /anthropic/v1/messages HTTP/1.1"
+    );
+    assert_eq!(
+        anthropic_body
+            .pointer("/messages/0/content/1/type")
+            .and_then(Value::as_str),
+        Some("image")
+    );
+}

--- a/crates/op-host-services/src/lib.rs
+++ b/crates/op-host-services/src/lib.rs
@@ -28,6 +28,8 @@ pub mod chat_claude;
 pub mod chat_copilot;
 pub mod chat_http_server;
 pub mod chat_intent;
+#[cfg(test)]
+mod chat_minimax_image_tests;
 pub mod chat_provider_llm;
 pub mod chat_runtime;
 pub mod chat_spawn;

--- a/crates/op-host-web/src/widget_host/agent_settings_press_tests.rs
+++ b/crates/op-host-web/src/widget_host/agent_settings_press_tests.rs
@@ -305,7 +305,7 @@ fn builtin_provider_menu_selects_ts_preset_for_draft() {
         .expect("draft remains open");
     assert_eq!(draft.preset, op_editor_core::BuiltinAgentPresetKey::MiniMax);
     assert_eq!(draft.display_name, "MiniMax");
-    assert_eq!(draft.model, "MiniMax-M2.7");
+    assert_eq!(draft.model, "MiniMax-M3");
     assert_eq!(draft.base_url, "https://api.minimaxi.com/anthropic");
 }
 


### PR DESCRIPTION
Reason: add target image capability using existing tool/provider pattern.

## Summary

- Make MiniMax M3 the built-in preset default.
- Send MiniMax M3 image attachments as native multimodal content in both supported API formats, including canvas-tool agent loops.
- Document global and China API bases while preserving existing MiniMax-M2.7 profiles.

## Checks

- `cargo fmt --all -- --check`
- `cargo test -p op-host-services chat_minimax_image_tests`
- `cargo test -p op-host-services`
- `cargo test -p op-editor-core builtin_agent_draft_can_select_ts_builtin_provider_preset`
- `cargo test -p op-host-native builtin_provider_menu_selects_ts_preset_for_draft`
- `cargo test -p op-host-web builtin_provider_menu_selects_ts_preset_for_draft`
- `cargo clippy -p op-host-services -p op-editor-core --all-targets -- -D warnings`

## Type

- [x] `feat` - New feature

## Checklist

- [x] No unrelated changes included
- [x] Commit messages follow Conventional Commits