### PR TITLE
fix(desktop): prefer .exe/.cmd/.bat over extensionless npm shims on Windows

### DIFF
--- a/crates/op-host-services/src/model_discovery.rs
+++ b/crates/op-host-services/src/model_discovery.rs
@@ -96,7 +96,7 @@ fn discovery_provider_order() -> [AgentProvider; 6] {
 /// side-effectful.
 pub fn resolve_cli(name: &str) -> Option<PathBuf> {
     let exts: &[&str] = if cfg!(windows) {
-        &["", ".exe", ".cmd", ".bat"]
+        &[".exe", ".cmd", ".bat", ""]
     } else {
         &[""]
     };


### PR DESCRIPTION
## Summary

- On Windows, npm global installs create an extensionless Unix shell script shim alongside `.cmd`/`.exe` files. `resolve_cli` previously tried the extensionless candidate first, which fails with "not a valid application for this OS platform" when spawned.
- Reorder the Windows extension list from `["", ".exe", ".cmd", ".bat"]` to `[".exe", ".cmd", ".bat", ""]` so real Windows executables are preferred over npm's extensionless shims.

## Test plan

- `cargo check --workspace`
- `cargo test -p op-host-services`
- Manual: connect OpenCode/Claude Code/Codex in OpenPencil on Windows and confirm models are discovered correctly.

Fixes #189
