### PR TITLE
fix(agent): update winget package name from GitHub.CopilotCLI to GitHub.Copilot

### DIFF
--- a/crates/op-host-services/src/provider_probe.rs
+++ b/crates/op-host-services/src/provider_probe.rs
@@ -158,7 +158,7 @@ fn install_command_for_platform(
             if macos {
                 "brew install github/copilot/copilot"
             } else if windows {
-                "winget install GitHub.CopilotCLI"
+                "winget install GitHub.Copilot"
             } else {
                 "See documentation"
             }


### PR DESCRIPTION
## Summary

- The official winget package for GitHub Copilot is `GitHub.Copilot`, not `GitHub.CopilotCLI`. The "CLI" suffix was removed from the package name. This fixes the install hint shown when GitHub Copilot is not detected on Windows.

```
- winget install GitHub.CopilotCLI

// should be

- winget install GitHub.Copilot
```
Ref: 
- [microsoft/winget-pkgs — GitHub.Copilot](https://github.com/microsoft/winget-pkgs/tree/master/manifests/g/GitHub/Copilot)
- https://github.com/features/copilot/cli

## Test plan

- `cargo check --workspace`
- Verified the correct package name against the official winget-pkgs manifest

---