### PR TITLE
fix(web): handle the new-from-template file-menu choice

### DIFF
--- a/crates/op-host-web/src/widget_host/chrome_menu_press.rs
+++ b/crates/op-host-web/src/widget_host/chrome_menu_press.rs
@@ -29,16 +29,17 @@ impl WidgetHost {
                 let Some(choice) = menu.choice_for_row(row) else {
                     return;
                 };
-                self.editor_state.editor_ui.pending_file_action = Some(match choice {
-                    FileMenuChoice::NewFile => FileAction::New,
-                    FileMenuChoice::OpenFile => FileAction::Open,
-                    FileMenuChoice::Save => FileAction::Save,
-                    FileMenuChoice::SaveAs => FileAction::SaveAs,
-                    FileMenuChoice::ExportImage => FileAction::ExportImage,
-                    FileMenuChoice::ExportAllFrames => FileAction::ExportAllFrames,
-                    FileMenuChoice::OpenRecent(i) => FileAction::OpenRecent(i),
-                    FileMenuChoice::ClearRecent => FileAction::ClearRecent,
-                });
+                self.editor_state.editor_ui.pending_file_action = match choice {
+                    FileMenuChoice::NewFile => Some(FileAction::New),
+                    FileMenuChoice::OpenFile => Some(FileAction::Open),
+                    FileMenuChoice::Save => Some(FileAction::Save),
+                    FileMenuChoice::SaveAs => Some(FileAction::SaveAs),
+                    FileMenuChoice::ExportImage => Some(FileAction::ExportImage),
+                    FileMenuChoice::ExportAllFrames => Some(FileAction::ExportAllFrames),
+                    FileMenuChoice::OpenRecent(i) => Some(FileAction::OpenRecent(i)),
+                    FileMenuChoice::ClearRecent => Some(FileAction::ClearRecent),
+                    FileMenuChoice::NewFromTemplate => None, // templates are desktop-only
+                };
                 self.editor_state.editor_ui.file_menu_open = false;
                 self.editor_state.editor_ui.file_menu.hover = None;
                 self.mark_dirty();


### PR DESCRIPTION
`v0.8.3` does not currently compile under the `canvaskit` feature:

```
error[E0004]: non-exhaustive patterns: `FileMenuChoice::NewFromTemplate` not covered
  --> crates/op-host-web/src/widget_host/chrome_menu_press.rs:32:78
error: could not compile `op-host-web` (lib) due to 1 previous error
```

`FileMenuChoice::NewFromTemplate` arrived with the scene-template work (`op-editor-ui/src/widgets/file_menu.rs:62`) and the native host was updated for it (`op-host-native/src/widget_host/property_input_dispatch.rs:206,213,233`), but the web host's `match` still lists the original eight variants. Rust requires exhaustive matches, so the web host stopped building.

## Why CI is red rather than warning

Two gates hit this and one does not, which is why it landed:

| Gate | Feature | Hits it |
| --- | --- | --- |
| `rust-check.yml:101` — `cargo test -p op-host-web --features canvaskit` | `canvaskit` | **yes** |
| `wasm-bundle-build.yml` — production bundle | `canvaskit` | **yes** |
| `rust-check.yml` / `wasm-bundle-check.yml` wasm compile guards | `web` | no |

The wasm guards check `--features web`, the stub, while the shipped bundle is built with `--features canvaskit`. So the compile guard passes on a feature set the artifact does not use.

## The fix

The arm yields `None` rather than a `FileAction`:

```rust
FileMenuChoice::NewFromTemplate => None, // templates are desktop-only
```

`FileAction` has no template variant and the template panel is not wired on web, so there is no action to dispatch. Returning early instead — which is what the native host's equivalent match does at `property_input_dispatch.rs:233` — would skip the three lines below that close the menu and clear hover, leaving the menu stuck open when the row is clicked. Yielding `None` dispatches nothing while still closing the menu, so the row is inert rather than broken.

That keeps the change behaviour-neutral for every existing menu row and leaves the template row a no-op on web until the panel is wired.

## Verification

- `cargo test -p op-host-web --features canvaskit` — now compiles and passes
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`

Found while rebasing #194 onto `v0.8.3`; it is unrelated to that change, hence a separate PR.
