### PR TITLE
fix(cli): preserve all read-nodes positional IDs

### DIFF
--- a/crates/op-cli/src/command_mappers.rs
+++ b/crates/op-cli/src/command_mappers.rs
@@ -111,8 +111,8 @@ pub(crate) fn map_delete(positionals: &[String], flags: &Flags) -> Result<Comman
 
 pub(crate) fn map_read_nodes(positionals: &[String], flags: &Flags) -> Result<Command, CliError> {
     let mut pairs = Vec::new();
-    if let Some(ids) = positionals.get(1) {
-        pairs.push(pair("nodeIds", ids.clone()));
+    if positionals.len() > 1 {
+        pairs.push(pair("nodeIds", positionals[1..].join(",")));
     }
     if let Some(depth) = flag_value(flags, "depth") {
         pairs.push(pair("depth", depth));

--- a/crates/op-cli/src/tests.rs
+++ b/crates/op-cli/src/tests.rs
@@ -565,6 +565,24 @@ fn parse_args_maps_read_nodes_to_ts_tool_shape() {
 }
 
 #[test]
+fn parse_args_keeps_each_read_nodes_positional_id() {
+    let p = parse_args(&[
+        "read-nodes".to_string(),
+        "n10".to_string(),
+        "n11".to_string(),
+    ])
+    .expect("parse");
+
+    assert_eq!(
+        p.command,
+        Command::ToolCall {
+            tool: "read_nodes".to_string(),
+            args: vec![("nodeIds".to_string(), "n10,n11".to_string())],
+        }
+    );
+}
+
+#[test]
 fn parse_args_maps_theme_preset_commands_to_ts_tool_shape() {
     let save = parse_args(&[
         "theme:save".to_string(),


### PR DESCRIPTION
## Summary

`op read-nodes [id...]` accepted multiple positional IDs but only forwarded the first one. It now preserves every ID in argument order.

## Changes

- Join all positional node IDs into the existing `nodeIds` argument.
- Add regression coverage for a two-ID invocation.

## Related Issues

N/A

## Type

- [x] `fix` — Bug fix

## Checklist

- [x] `cargo test -p op-cli` (114 passed)
- [x] `cargo clippy -p op-cli --all-targets -- -D warnings`
- [x] Changed Rust files pass `rustfmt --check`
- [x] No unrelated changes included
- [x] Commit messages follow Conventional Commits