### PR TITLE
fix(cli): resolve the newest pre-release tag in the Windows installer

### DIFF
--- a/scripts/install-op.ps1
+++ b/scripts/install-op.ps1
@@ -22,7 +22,11 @@ function Resolve-Version {
 
   $AllowPreRelease = $PreRelease.IsPresent -or $env:OP_PRERELEASE -in @("1", "true", "TRUE", "yes", "YES")
   if ($AllowPreRelease) {
-    $Latest = Invoke-RestMethod -Uri "https://api.github.com/repos/$Owner/$Repo/releases" | Select-Object -First 1
+    # Invoke-RestMethod emits a JSON array as a single pipeline object, so
+    # `| Select-Object -First 1` yields the whole array and `.tag_name` then
+    # member-enumerates every tag. Assign first, then index.
+    $Releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Owner/$Repo/releases"
+    $Latest = @($Releases)[0]
   } else {
     $Latest = Invoke-RestMethod -Uri "https://api.github.com/repos/$Owner/$Repo/releases/latest"
   }


### PR DESCRIPTION
## Summary

The PowerShell installer's pre-release path builds a malformed download URL and always 404s, so `scripts/install-op.ps1` cannot install `op` on Windows. `Invoke-RestMethod` emits a JSON array as a *single* pipeline object, so `| Select-Object -First 1` returns the whole 30-element release array rather than its first element.

## Changes

- `scripts/install-op.ps1` — assign the `/releases` response to a variable and index it, instead of piping through `Select-Object -First 1`.

### Why it fails

`Resolve-Version` did:

```powershell
$Latest = Invoke-RestMethod -Uri ".../releases" | Select-Object -First 1
```

Because the array arrives as one pipeline item, `-First 1` passes it straight through. `$Latest.tag_name` then hits PowerShell's member enumeration and returns **every** tag, which `TrimStart("v")` flattens into a single space-joined string:

```
==> Installing op 0.8.4 0.8.3 0.8.2 ... 0.1.0 0.0.3 (windows-x86_64)
    from https://github.com/ZSeven-W/openpencil/releases/download/v0.8.4 0.8.3 ... 0.0.3/op-cli-windows-x86_64.zip
Invoke-WebRequest: Not Found
```

Note that `@(Invoke-RestMethod ...)[0]` does **not** fix this — `@()` wraps the single pipeline object, so `[0]` is still the whole array. Assigning first is what unwraps it.

### Why this affects every Windows user

Two things have to line up, and both currently do:

1. Every published release is marked **pre-release**, so `/releases/latest` returns 404 and the non-pre-release path is unusable. `OP_PRERELEASE=1` is the only route that reaches a download — and it is the broken one.
2. `$DefaultOpVersion` is stamped by `rust-release.yml` into the *release-asset* copy of the script only. The copy on `main` is unstamped, so it always goes through `Resolve-Version` — and `main` is exactly what the README's install line fetches:

   ```powershell
   irm https://raw.githubusercontent.com/ZSeven-W/openpencil/main/scripts/install-op.ps1 | iex
   ```

The bash installer is unaffected; it pipes through `head -n1`.

### Verification

Before — `-PreRelease` against `main`: 404, per the transcript above.

After, on Windows 11 x86_64 / PowerShell 7:

```
==> Installing op 0.8.4 (windows-x86_64)
    from https://github.com/ZSeven-W/openpencil/releases/download/v0.8.4/op-cli-windows-x86_64.zip
Added C:\Users\<user>\.openpencil\bin to the user PATH. Restart the shell to use op globally.
==> Done. Run 'op --version' to verify.
{"version":"0.8.4"}
```

Binary confirmed independently: `op --help` prints the CLI usage banner, 11,032,576 bytes, matching the v0.8.4 asset.

## Related Issues

None filed — found while installing the CLI on Windows 11.

## Type

- [ ] `feat` — New feature
- [x] `fix` — Bug fix
- [ ] `refactor` — Code refactoring (no behavior change)
- [ ] `perf` — Performance improvement
- [ ] `docs` — Documentation
- [ ] `test` — Tests
- [ ] `chore` — Build / tooling / dependencies

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] No unrelated changes included
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Note for maintainers (not addressed here)

Once this lands, the plain README install line still 404s for anyone who doesn't set `OP_PRERELEASE=1`, because no release is marked as the stable latest. That's a release-tagging call rather than a script fix, so I left it alone — but either marking one release stable or leading the README's Windows block with the `OP_PRERELEASE=1` variant would finish the job.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
