### PR TITLE
fix(agent): match the Codex env allowlist case-insensitively

### DIFF
--- a/crates/op-host-services/src/chat_subprocess_quirks.rs
+++ b/crates/op-host-services/src/chat_subprocess_quirks.rs
@@ -49,8 +49,11 @@ const CODEX_ENV_ALLOWLIST: &[&str] = &[
     "http_proxy",
     "https_proxy",
     "no_proxy",
-    // Windows-essential vars
+    // Windows-essential vars. Matched case-insensitively (see
+    // `codex_env_allowed`) because Windows reports these in their native
+    // casing, e.g. `SystemRoot` / `windir` / `ComSpec` / `SystemDrive`.
     "SYSTEMROOT",
+    "WINDIR",
     "COMSPEC",
     "USERPROFILE",
     "APPDATA",
@@ -118,14 +121,35 @@ fn load_codex_config_env_keys() -> Vec<String> {
 /// prefixes + config.toml `env_key` opt-ins (TS `filterCodexEnv`).
 pub fn codex_child_env() -> Vec<(String, String)> {
     let extra = load_codex_config_env_keys();
-    std::env::vars()
-        .filter(|(k, _)| {
-            CODEX_ENV_ALLOWLIST.contains(&k.as_str())
-                || extra.iter().any(|e| e == k)
-                || k.starts_with("OPENAI_")
-                || k.starts_with("CODEX_")
-        })
+    filter_codex_env(std::env::vars(), &extra)
+}
+
+fn filter_codex_env<I>(vars: I, extra: &[String]) -> Vec<(String, String)>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    vars.into_iter()
+        .filter(|(key, _)| codex_env_allowed(key, extra))
         .collect()
+}
+
+/// Windows environment keys are case-insensitive, and the OS hands them to a
+/// process in their native casing — `SystemRoot`, `windir`, `ComSpec`,
+/// `SystemDrive`, `Path`. An exact match against the uppercase allowlist
+/// therefore dropped every one of them, and a Codex child launched without
+/// `SystemRoot` cannot load the Winsock service providers under
+/// `%SystemRoot%\System32`: the turn dies with `WSAEPROVIDERFAILEDINIT`
+/// (os error 10106). Compare the system allowlist case-insensitively, the way
+/// `op_acp::client::local_env_allowed` already does. The `env_key` opt-ins and
+/// the `OPENAI_` / `CODEX_` prefixes stay exact: those are provider names the
+/// user spells out, not host variables.
+fn codex_env_allowed(key: &str, extra: &[String]) -> bool {
+    CODEX_ENV_ALLOWLIST
+        .iter()
+        .any(|allowed| allowed.eq_ignore_ascii_case(key))
+        || extra.iter().any(|e| e == key)
+        || key.starts_with("OPENAI_")
+        || key.starts_with("CODEX_")
 }
 
 /// Budget for the one-shot `codex exec --help` capability probe. Generous
@@ -414,6 +438,75 @@ pub fn codex_reasoning_effort(thinking: ThinkingMode, effort: EffortLevel) -> Op
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn owned(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    /// Windows hands the environment over in its native casing, so the
+    /// allowlist has to match case-insensitively. Losing `SystemRoot` here is
+    /// what made the Codex turn fail Winsock init with os error 10106.
+    #[test]
+    fn codex_env_keeps_windows_native_key_casing() {
+        let kept = filter_codex_env(
+            owned(&[
+                ("SystemRoot", r"C:\Windows"),
+                ("windir", r"C:\Windows"),
+                ("ComSpec", r"C:\Windows\System32\cmd.exe"),
+                ("SystemDrive", "C:"),
+                ("Path", r"C:\Windows\System32"),
+                ("PathExt", ".COM;.EXE;.BAT;.CMD"),
+                ("UserProfile", r"C:\Users\dev"),
+            ]),
+            &[],
+        );
+        let names: Vec<&str> = kept.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "SystemRoot",
+                "windir",
+                "ComSpec",
+                "SystemDrive",
+                "Path",
+                "PathExt",
+                "UserProfile",
+            ]
+        );
+    }
+
+    /// The relaxed casing must not widen the secret boundary: only the
+    /// allowlist, the `OPENAI_` / `CODEX_` prefixes and the config.toml
+    /// `env_key` opt-ins get through.
+    #[test]
+    fn codex_env_still_filters_secrets_and_honours_opt_ins() {
+        let kept = filter_codex_env(
+            owned(&[
+                ("SystemRoot", r"C:\Windows"),
+                ("ANTHROPIC_API_KEY", "secret"),
+                ("GITHUB_TOKEN", "secret"),
+                ("AWS_SECRET_ACCESS_KEY", "secret"),
+                ("ALL_PROXY", "socks5://127.0.0.1:7897"),
+                ("OPENAI_API_KEY", "sk-test"),
+                ("CODEX_HOME", "/tmp/codex"),
+                ("MY_PROVIDER_KEY", "opted-in"),
+            ]),
+            &["MY_PROVIDER_KEY".to_string()],
+        );
+        let names: Vec<&str> = kept.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "SystemRoot",
+                "OPENAI_API_KEY",
+                "CODEX_HOME",
+                "MY_PROVIDER_KEY",
+            ]
+        );
+    }
 
     #[test]
     fn codex_config_env_keys_extracts_quoted_values() {


### PR DESCRIPTION
Fixes #229.

## What breaks

`codex_child_env()` filtered the host environment with an exact match:

```rust
CODEX_ENV_ALLOWLIST.contains(&k.as_str())
```

Windows environment keys are case-insensitive, and the OS hands them to a process in their *native* casing — `SystemRoot`, `windir`, `ComSpec`, `SystemDrive`, `Path`, `PathExt`. None of those match the uppercase allowlist entries, so on Windows the filter dropped **every** host variable and the Codex child was launched with nothing but its `OPENAI_*` / `CODEX_*` inheritance.

A process without `SystemRoot` cannot load the Winsock service providers under `%SystemRoot%\System32`, which is exactly the failure in #229:

```
stream disconnected before completion:
The requested service provider could not be loaded or initialized. (os error 10106)
```

`10106` is `WSAEPROVIDERFAILEDINIT`. It also explains why the same `codex.exe` works from a terminal — there it inherits a complete environment.

`WINDIR` was additionally missing from the allowlist outright.

## The fix

Compare the system allowlist with `eq_ignore_ascii_case`, and add `WINDIR`. This is the same normalization `op_acp::client::local_env_allowed` already applies, with the same comment explaining why — this call path had just not been brought in line.

The secret boundary is unchanged: the `env_key` opt-ins from `~/.codex/config.toml` and the `OPENAI_` / `CODEX_` prefixes stay exact matches, because those are provider names the user spells out rather than host variables. `ALL_PROXY` stays excluded as the existing comment requires.

The filter body moved into `filter_codex_env(vars, extra)` so it can be tested without mutating the process environment — the same shape `chat_subprocess_safety::filtered_env` already uses.

## How verified

Platform: Windows 11 x64, toolchain 1.94.1 (the `rust-toolchain.toml` pin), branch `v0.8.5` at `ab82e8b2`.

Two regression tests were added. They are pure-function tests, so they run on every platform, not just Windows.

**Fail before** — with the fix reverted to `CODEX_ENV_ALLOWLIST.contains(&key)` and `WINDIR` removed:

```
running 2 tests
test chat_subprocess_quirks::tests::codex_env_still_filters_secrets_and_honours_opt_ins ... FAILED
test chat_subprocess_quirks::tests::codex_env_keeps_windows_native_key_casing ... FAILED

---- codex_env_keeps_windows_native_key_casing ----
assertion `left == right` failed
  left: []
 right: ["SystemRoot", "windir", "ComSpec", "SystemDrive", "Path", "PathExt", "UserProfile"]

---- codex_env_still_filters_secrets_and_honours_opt_ins ----
assertion `left == right` failed
  left: ["OPENAI_API_KEY", "CODEX_HOME", "MY_PROVIDER_KEY"]
 right: ["SystemRoot", "OPENAI_API_KEY", "CODEX_HOME", "MY_PROVIDER_KEY"]
```

`left: []` is the bug in one line — every host variable gone.

**Pass after:**

```
$ cargo test -p op-host-services --lib codex_env
test chat_subprocess_quirks::tests::codex_env_still_filters_secrets_and_honours_opt_ins ... ok
test chat_subprocess_quirks::tests::codex_env_keeps_windows_native_key_casing ... ok
test result: ok. 2 passed; 0 failed
```

Full crate suite and gates:

- `cargo test -p op-host-services` → `1157 passed; 2 failed`. Both failures (`chat_subprocess::tests::antigravity_and_grok_use_documented_one_shot_flags`, `chat_subprocess::tests::for_cli_claude_code_seeds_print_stream_json_flags`) reproduce identically on a clean `v0.8.5` checkout with this change stashed — pre-existing and unrelated (they assume extensionless binary names, which Windows resolves as `.exe`).
- `cargo fmt --all -- --check` → clean
- `cargo clippy -p op-host-services --all-targets -- -D warnings` → clean

The file stays under the 800-line cap (653 lines).
