### PR TITLE
fix(agent): keep the natively-cased Windows vars for guarded CLIs

### DIFF
--- a/crates/op-host-services/src/chat_subprocess_safety.rs
+++ b/crates/op-host-services/src/chat_subprocess_safety.rs
@@ -290,11 +290,11 @@ pub fn append_isolated_env(env: &mut Vec<(String, String)>, turn: Option<&Isolat
         #[cfg(windows)]
         let safe_path = env
             .iter()
-            .find(|(key, _)| key == "SYSTEMROOT")
+            .find(|(key, _)| key.eq_ignore_ascii_case("SYSTEMROOT"))
             .map(|(_, root)| format!(r"{root}\System32;{root}"))
             .unwrap_or_else(|| r"C:\Windows\System32;C:\Windows".to_string());
         const PRIVATE_KEYS: &[&str] = &["PATH", "TMPDIR", "TMP", "TEMP"];
-        env.retain(|(key, _)| !PRIVATE_KEYS.contains(&key.as_str()));
+        env.retain(|(key, _)| !env_key_listed(PRIVATE_KEYS, key));
         let value = |path: &Path| path.to_string_lossy().into_owned();
         env.extend([
             ("PATH".to_string(), safe_path),
@@ -533,6 +533,17 @@ where
         .collect()
 }
 
+/// Windows environment keys are case-insensitive and the OS hands them to a
+/// process in their native casing — `Path`, `SystemRoot`, `windir`, `ComSpec`,
+/// `ProgramData`. Matching an uppercase list with `contains` therefore drops
+/// every one of them: a guarded CLI then starts with no `Path` and no
+/// `SystemRoot`, and a child that cannot reach `%SystemRoot%\System32` fails
+/// Winsock initialization with `WSAEPROVIDERFAILEDINIT` (os error 10106).
+/// `chat_spawn::scrubbed_child_env` already compares this way.
+fn env_key_listed(list: &[&str], key: &str) -> bool {
+    list.iter().any(|entry| entry.eq_ignore_ascii_case(key))
+}
+
 fn allowed_env(cli: CliName, key: &str) -> bool {
     const COMMON: &[&str] = &[
         "HOME",
@@ -566,7 +577,7 @@ fn allowed_env(cli: CliName, key: &str) -> bool {
         "REQUESTS_CA_BUNDLE",
         "CURL_CA_BUNDLE",
     ];
-    if COMMON.contains(&key) || key.starts_with("LC_") {
+    if env_key_listed(COMMON, key) || key.starts_with("LC_") {
         return true;
     }
     match cli {

--- a/crates/op-host-services/src/chat_subprocess_safety_tests.rs
+++ b/crates/op-host-services/src/chat_subprocess_safety_tests.rs
@@ -205,3 +205,82 @@ fn antigravity_keeps_linux_keyring_session_but_grok_does_not() {
         assert!(!allowed_env(CliName::GrokBuild, key), "{key}");
     }
 }
+
+/// Windows hands the environment over in its native casing, so an uppercase
+/// allowlist matched with `contains` drops `Path`, `SystemRoot`, `windir`,
+/// `ComSpec` and `ProgramData` — the guarded CLI then starts with no PATH and
+/// no Winsock provider root.
+#[test]
+fn guarded_child_env_keeps_windows_native_key_casing() {
+    let vars = vec![
+        ("Path".to_string(), r"C:\Windows\System32".to_string()),
+        ("SystemRoot".to_string(), r"C:\Windows".to_string()),
+        ("windir".to_string(), r"C:\Windows".to_string()),
+        (
+            "ComSpec".to_string(),
+            r"C:\Windows\System32\cmd.exe".to_string(),
+        ),
+        ("ProgramData".to_string(), r"C:\ProgramData".to_string()),
+        ("UserProfile".to_string(), r"C:\Users\dev".to_string()),
+        ("DATABASE_URL".to_string(), "secret".to_string()),
+    ];
+
+    for cli in [CliName::GrokBuild, CliName::Antigravity, CliName::Dsh] {
+        let keys: Vec<String> = filtered_env(cli, vars.clone())
+            .into_iter()
+            .map(|(key, _)| key)
+            .collect();
+        assert_eq!(
+            keys,
+            vec![
+                "Path",
+                "SystemRoot",
+                "windir",
+                "ComSpec",
+                "ProgramData",
+                "UserProfile",
+            ],
+            "{cli:?} dropped natively-cased Windows keys"
+        );
+    }
+}
+
+/// The private-HOME rewrite has to find `SystemRoot` in its real casing to
+/// build the sandbox PATH, and has to strip the inherited `Path` rather than
+/// leave a second, host-valued entry behind it.
+#[test]
+#[cfg(windows)]
+fn isolated_env_reads_native_cased_system_root_and_strips_host_path() {
+    let turn = IsolatedTurn::prepare_for(
+        Some(CliName::Antigravity),
+        "return only JavaScript",
+        &[],
+        TurnPurpose::Generation,
+        None,
+    )
+    .unwrap()
+    .unwrap();
+
+    let mut env = vec![
+        ("Path".to_string(), r"C:\host\tools".to_string()),
+        ("SystemRoot".to_string(), r"D:\Windows".to_string()),
+        ("TEMP".to_string(), r"C:\host\temp".to_string()),
+    ];
+    append_isolated_env(&mut env, Some(&turn));
+
+    let path_entries: Vec<&(String, String)> = env
+        .iter()
+        .filter(|(key, _)| key.eq_ignore_ascii_case("PATH"))
+        .collect();
+    assert_eq!(
+        path_entries.len(),
+        1,
+        "the host PATH must be replaced, not shadowed: {env:?}"
+    );
+    assert_eq!(path_entries[0].1, r"D:\Windows\System32;D:\Windows");
+    let temp = env
+        .iter()
+        .find(|(key, _)| key == "TEMP")
+        .expect("private TEMP");
+    assert!(Path::new(&temp.1).starts_with(turn.cwd()), "{temp:?}");
+}


### PR DESCRIPTION
Same root cause as #229 / #232, on the other subprocess spawn path. Filed separately because it is a different function, a different set of CLIs, and independently verifiable.

## What breaks

`chat_subprocess_safety::allowed_env` gates the child environment for the guarded CLIs with an exact match against an uppercase list:

```rust
if COMMON.contains(&key) || key.starts_with("LC_") {
```

Windows environment keys are case-insensitive and the OS hands them to a process in their native casing — `Path`, `SystemRoot`, `windir`, `ComSpec`, `ProgramData`. None of those match, so on Windows `child_env` returns an environment with **no PATH at all**, for every caller:

- `chat_subprocess_lifecycle::child_env_for_cli` → Antigravity, Grok, `dsh` chat turns
- `cli_probe_support` → the OpenCode / Antigravity / Grok / dsh capability probes

A child with no `SystemRoot` cannot load the Winsock service providers under `%SystemRoot%\System32` and fails with `WSAEPROVIDERFAILEDINIT` (os error 10106) — the failure reported in #229 for Codex. A child with no `Path` additionally cannot resolve its own interpreter: `dsh`'s doc comment in this very file says it "needs the merged login-shell PATH (already in COMMON)", which on Windows it never received.

`append_isolated_env` carries the same defect twice more:

```rust
let safe_path = env.iter().find(|(key, _)| key == "SYSTEMROOT")
    .map(|(_, root)| format!(r"{root}\System32;{root}"))
    .unwrap_or_else(|| r"C:\Windows\System32;C:\Windows".to_string());
const PRIVATE_KEYS: &[&str] = &["PATH", "TMPDIR", "TMP", "TEMP"];
env.retain(|(key, _)| !PRIVATE_KEYS.contains(&key.as_str()));
```

The `SYSTEMROOT` lookup never matches `SystemRoot`, so the private-HOME sandbox PATH always takes the hard-coded `C:\Windows` fallback — wrong on any machine whose Windows lives elsewhere. And the strip leaves the inherited `Path` sitting in the vector next to the sandbox `PATH` that is pushed right after it, which is not what a containment boundary should look like even though `Command`'s Windows env map happens to collapse the pair.

## The fix

One helper, `env_key_listed`, comparing with `eq_ignore_ascii_case`, used at all three sites. This is exactly how `chat_spawn::scrubbed_child_env` in the same crate already matches its `DANGEROUS` list, and how `op_acp::client::local_env_allowed` matches its allowlist.

No entries were added or removed and the per-CLI arms are untouched, so the secret boundary is unchanged: `OPENPENCIL_MCP_TOKEN`, `DATABASE_URL` and cross-provider API keys stay excluded.

## How verified

Platform: Windows 11 x64, toolchain 1.94.1 (`rust-toolchain.toml` pin), branch `v0.8.5` at `ab82e8b2`.

Two regression tests added to `chat_subprocess_safety_tests.rs`. The allowlist one is a pure-function test and runs on every platform; the isolated-env one is `#[cfg(windows)]` because the sandbox PATH branch is.

**Fail before** — with the three call sites restored to their exact-match form:

```
---- guarded_child_env_keeps_windows_native_key_casing ----
assertion `left == right` failed: GrokBuild dropped natively-cased Windows keys
  left: []
 right: ["Path", "SystemRoot", "windir", "ComSpec", "ProgramData", "UserProfile"]

---- isolated_env_reads_native_cased_system_root_and_strips_host_path ----
(fails: two PATH-ish entries survive, and the sandbox PATH reads C:\Windows
 instead of the D:\Windows the fixture supplies as SystemRoot)

test result: FAILED. 13 passed; 2 failed
```

`left: []` is the whole bug — the guarded CLI gets nothing.

**Pass after:**

```
$ cargo test -p op-host-services --lib chat_subprocess_safety
test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 1144 filtered out
```

Gates:

- `cargo test -p op-host-services` → `1157 passed; 2 failed`. Both failures (`chat_subprocess::tests::antigravity_and_grok_use_documented_one_shot_flags`, `chat_subprocess::tests::for_cli_claude_code_seeds_print_stream_json_flags`) reproduce identically on a clean `v0.8.5` checkout with this change stashed — pre-existing and unrelated.
- `cargo fmt --all -- --check` → clean
- `cargo clippy -p op-host-services --all-targets -- -D warnings` → clean

`chat_subprocess_safety.rs` stays under the 800-line cap (730 lines).
