### PR TITLE
fix(ai): restore --destructive to the saturated-accent tokens

### DIFF
--- a/crates/op-orchestrator/src/role_post_pass/color_utils.rs
+++ b/crates/op-orchestrator/src/role_post_pass/color_utils.rs
@@ -132,8 +132,7 @@ pub(super) fn is_saturated_accent_token(color: &str) -> bool {
     let t = color.trim().trim_start_matches('$').to_ascii_lowercase();
     const ROOTS: &[&str] = &[
         "--primary",
-        "--primary",
-        "--color-error",
+        "--destructive",
         "--color-error",
         "--color-success",
     ];

--- a/crates/op-orchestrator/src/role_post_pass/contrast.rs
+++ b/crates/op-orchestrator/src/role_post_pass/contrast.rs
@@ -14,7 +14,7 @@ pub(super) fn fix_button_foreground_contrast(node: &mut Value) {
     let Some(bg_raw) = get_first_solid_color(node) else {
         return;
     };
-    // A brand-accent token (`$--primary` / `$--primary`) binds to a
+    // A brand-accent token (`$--primary` / `$--destructive`) binds to a
     // concrete hex only at render time, so `resolve_color_maybe_ref` can't
     // read its luminance here and the pass used to bail — leaving the model's
     // default-dark icon on an orange accent button (measured: a `sliders`

--- a/crates/op-orchestrator/src/role_post_pass_contrast_tests.rs
+++ b/crates/op-orchestrator/src/role_post_pass_contrast_tests.rs
@@ -21,9 +21,44 @@ fn button_dark_bg_gets_white_text() {
     );
 }
 
+/// The shadcn rename (c40a4f69) rewrote the five saturated-accent roots in
+/// place and landed `--primary` and `--color-error` twice each, so the token
+/// the old `color-danger` maps to — `--destructive`, seeded at `#EF4444` with
+/// a `#FFFFFF` foreground — fell out of the list. A destructive button then
+/// took the `None => return` arm and kept the model's default-dark icon.
+#[test]
+fn destructive_token_button_flips_dark_icon_to_white() {
+    for token in ["$--destructive", "$--color-error", "$--color-success"] {
+        let mut btn = json!({
+            "type":"frame","role":"icon-button",
+            "fill":[{"type":"solid","color": token}],
+            "children":[{"type":"icon_font","iconFontName":"trash",
+                "fill":[{"type":"solid","color":"#0F172A"}]}]
+        });
+        fix_button_foreground_contrast(&mut btn);
+        assert_eq!(
+            btn["children"][0]["fill"],
+            json!([{"type":"solid","color":"#FFFFFF"}]),
+            "{token} button must flip its dark icon to white"
+        );
+    }
+
+    // `--color-warning` stays excluded: a light amber reads better dark.
+    let mut warning = json!({
+        "type":"frame","role":"icon-button",
+        "fill":[{"type":"solid","color":"$--color-warning"}],
+        "children":[{"type":"icon_font","fill":[{"type":"solid","color":"#0F172A"}]}]
+    });
+    fix_button_foreground_contrast(&mut warning);
+    assert_eq!(
+        warning["children"][0]["fill"],
+        json!([{"type":"solid","color":"#0F172A"}])
+    );
+}
+
 #[test]
 fn accent_token_button_flips_dark_icon_to_white() {
-    // Regression: a `$--primary` (or `$--primary`) button binds its bg
+    // Regression: a `$--primary` (or `$--destructive`) button binds its bg
     // hex only at render time, so the contrast pass could not read its
     // luminance and left the model's default-dark icon on the orange accent.
     let mut btn = json!({


### PR DESCRIPTION
## What breaks

`c40a4f69` ("feat(variables): adopt the shadcn variable dictionary") rewrote the saturated-accent root list in place:

```diff
     const ROOTS: &[&str] = &[
-        "color-accent",
-        "color-primary",
-        "color-danger",
-        "color-error",
-        "color-success",
+        "--primary",
+        "--primary",
+        "--color-error",
+        "--color-error",
+        "--color-success",
     ];
```

Five distinct roots went in, three came out — `--primary` and `--color-error` each landed twice. The token `color-danger` maps to in the new dictionary is `--destructive`, seeded in `design_system.rs` at `#EF4444` with `destructive-foreground` = `#FFFFFF`. It is exactly what the doc comment describes ("a saturated, mid-dark colour needing a WHITE foreground") and it is now absent from the list.

`is_saturated_accent_token` has one caller, and it is load-bearing (`role_post_pass/contrast.rs`):

```rust
let bg = match resolve_color_maybe_ref(&bg_raw) {
    Some(bg) if hex_luminance(&bg).is_some() => bg,
    Some(_) => return,
    None if is_saturated_accent_token(&bg_raw) => "#EA580C".to_string(),
    None => return,          // ← unresolved ref, no repair
};
```

A `$`-ref background has no hex at sub-agent time, so this predicate is the only thing that lets `fix_button_foreground_contrast` treat the button as dark and flip its children to white. With `--destructive` missing, a destructive button takes the `None => return` arm.

**Symptom:** a generated destructive button keeps the model's default-dark icon/label on red. `#0F172A` on `#EF4444` is about 2.6:1 — below WCAG AA — and it is precisely the failure the function's own doc comment cites for the accent case.

## The fix

Four distinct roots: `--primary`, `--destructive`, `--color-error`, `--color-success`. (Four rather than five is correct — the old vocabulary had *both* `color-accent` and `color-primary`, and shadcn's `--accent` is a light neutral, `#F3F4F6`, which does not belong in this list.) `--color-warning` stays excluded, as its comment requires.

Also corrects the same rename artifact in the caller's comment, which reads ``(`$--primary` / `$--primary`)``.

I left `--sidebar-primary` and `--color-info` alone even though both are seeded saturated with `#FFFFFF` foregrounds, and `tree_heuristics_text_band::is_accent_ref` already treats `$--sidebar-primary` as one class with `$--primary` — happy to add them if you want, but this PR is a strict repair of the rename rather than a widening.

## How verified

Platform: Windows 11 x64, toolchain 1.94.1 (`rust-toolchain.toml` pin), branch `v0.8.5` at `ab82e8b2`.

New test `destructive_token_button_flips_dark_icon_to_white` in `role_post_pass_contrast_tests.rs`, next to the existing `accent_token_button_flips_dark_icon_to_white`. It covers all three state tokens plus the `--color-warning` negative case.

**Fail before** — with the duplicated list restored:

```
---- role_post_pass::contrast_tests::destructive_token_button_flips_dark_icon_to_white ----
assertion `left == right` failed: $--destructive button must flip its dark icon to white
  left:  Array [Object {"type": "solid", "color": "#0F172A"}]
 right:  Array [Object {"type": "solid", "color": "#FFFFFF"}]
```

**Pass after:**

```
$ cargo test -p op-orchestrator --lib destructive_token
test role_post_pass::contrast_tests::destructive_token_button_flips_dark_icon_to_white ... ok
test result: ok. 1 passed; 0 failed
```

Gates:

- `cargo test -p op-orchestrator` → `1747 passed; 0 failed; 6 ignored` (includes the vocabulary guard test)
- `cargo fmt --all -- --check` → clean
- `cargo clippy -p op-orchestrator --all-targets -- -D warnings` → clean
