### PR TITLE
fix(editor): address restored blobs with git's path separator

### DIFF
--- a/crates/op-git/src/status.rs
+++ b/crates/op-git/src/status.rs
@@ -225,6 +225,14 @@ impl GitRepo {
         let Some(rel_str) = rel.to_str() else {
             return Ok(());
         };
+        // `<rev>:<path>` addresses a *tree* entry, and git tree entries are
+        // `/`-separated on every platform. `rel_to_workdir` hands back an OS
+        // path, so on Windows this is `designs\home.op` and the lookup misses
+        // for anything below the repository root — only a root-level file, which
+        // has no separator, resolves. `git_session::tracked_relpath` normalizes
+        // for the same reason; `MAIN_SEPARATOR` keeps a literal backslash in a
+        // Unix filename intact.
+        let rel_str = rel_str.replace(std::path::MAIN_SEPARATOR, "/");
         let object = repo.revparse_single(&format!("{commit}:{rel_str}"))?;
         let blob = object.peel_to_blob()?;
         let abs = self.workdir().join(&rel);

--- a/crates/op-git/src/tests_repo.rs
+++ b/crates/op-git/src/tests_repo.rs
@@ -143,6 +143,30 @@ fn restore_reverts_a_modified_file() {
     assert_eq!(content, "committed");
 }
 
+/// The git panel restores through `git_session.tracked_file()`, an absolute
+/// path, so `rel_to_workdir` yields an OS-separated relative path. A `<rev>:
+/// <path>` revspec only understands `/`, so on Windows every document below
+/// the repository root failed to resolve — root-level files happened to work
+/// because they carry no separator, which is why both existing tests missed it.
+#[test]
+fn restore_reverts_a_file_below_the_repository_root() {
+    let Some(tr) = TempRepo::new("restore-subdir") else {
+        return;
+    };
+    std::fs::create_dir_all(tr.dir.join("designs")).expect("mkdir");
+    tr.write("designs/a.op", "committed");
+    tr.repo.stage_all().expect("stage");
+    tr.repo.commit("init").expect("commit");
+
+    let absolute = tr.dir.join("designs").join("a.op");
+    std::fs::write(&absolute, "scratch edit").expect("write");
+    assert!(!tr.repo.status().expect("status").is_clean());
+
+    tr.repo.restore(&absolute, "HEAD").expect("restore");
+    assert_eq!(std::fs::read_to_string(&absolute).unwrap(), "committed");
+    assert!(tr.repo.status().expect("status").is_clean());
+}
+
 #[test]
 fn restore_rolls_a_file_back_to_an_older_commit() {
     let Some(tr) = TempRepo::new("restore-commit") else {


### PR DESCRIPTION
## What breaks

`GitRepo::restore` builds a revspec from an OS path:

```rust
let rel = self.rel_to_workdir(path);
let Some(rel_str) = rel.to_str() else { return Ok(()); };
let object = repo.revparse_single(&format!("{commit}:{rel_str}"))?;
```

`rel_to_workdir` returns a `PathBuf` from `strip_prefix` of an absolute OS path, so on Windows `rel_str` is `designs\home.op`. A `<rev>:<path>` revspec addresses a **tree entry**, and git tree entries are `/`-separated on every platform — `\` is just an ordinary byte in an entry name. libgit2 answers exactly that:

```
the path 'designs\a.op' does not exist in the given tree
```

**Symptom:** Git panel → commit row → **Restore this version** fails on Windows for every document that is not sitting in the repository root. `git_host.rs` dispatches `GitPanelAction::RestoreCommit` with `git_session.tracked_file()`, an absolute path, so the separator is always present in practice. A root-level `.op` file happens to work because it has no separator to get wrong — which is also why both existing `restore` tests missed this: they use `Path::new("a.op")`.

## The fix

One line, normalizing before the revspec is formatted. `git_session::tracked_relpath` already does the same thing for the same reason, and `blob_at_commit` — the other revspec builder in this file — is safe only because its caller feeds it that already-normalized value. `restore` is the one path that bypasses it.

`MAIN_SEPARATOR` rather than a literal `'\'` so a backslash inside a filename, which is legal on Unix, is left alone.

## How verified

Platform: Windows 11 x64, toolchain 1.94.1 (`rust-toolchain.toml` pin), branch `v0.8.5` at `ab82e8b2`.

New test `restore_reverts_a_file_below_the_repository_root` in `tests_repo.rs`, alongside the two existing `restore` tests. It passes the absolute path the git panel actually passes, so it exercises the real caller shape.

The test is not `#[cfg(windows)]`-gated: it is a genuine invariant on every platform and guards the behaviour on Windows CI. On Unix it passes with or without the fix, since `MAIN_SEPARATOR` is already `/`.

**Fail before** — with the normalization line removed:

```
---- tests_repo::restore_reverts_a_file_below_the_repository_root ----
panicked at crates\op-git\src\tests_repo.rs:165:40:
restore: Command { operation: "libgit2",
  stderr: "the path 'designs\a.op' does not exist in the given tree" }

test result: FAILED. 2 passed; 1 failed
```

**Pass after:**

```
$ cargo test -p op-git
test tests_repo::restore_reverts_a_file_below_the_repository_root ... ok
test result: ok. 33 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Gates:

- `cargo fmt --all -- --check` → clean
- `cargo clippy -p op-git --all-targets -- -D warnings` → clean
