### PR TITLE
fix(agent): probe Windows executable extensions before the bare name

### DIFF
--- a/crates/op-acp/src/client.rs
+++ b/crates/op-acp/src/client.rs
@@ -520,11 +520,18 @@ fn command_candidates(command: &str, path: &str) -> Vec<PathBuf> {
     let mut out = Vec::new();
     for dir in std::env::split_paths(path) {
         let base = dir.join(command);
-        out.push(base.clone());
+        // Windows executable extensions lead: `CreateProcessW` cannot run an
+        // extensionless file, and `npm i -g` leaves a POSIX `foo` shell script
+        // next to `foo.cmd` / `foo.ps1`. `is_executable_candidate` is only an
+        // `is_file()` check off Unix, so probing the bare name first selects
+        // that shell script and `build_local_command` — which dispatches on
+        // the resolved extension — falls through to a direct spawn that fails
+        // with os error 193. The npm fallback block below already omits it.
         #[cfg(windows)]
         for ext in ["exe", "cmd", "bat", "com", "ps1"] {
             out.push(base.with_extension(ext));
         }
+        out.push(base);
     }
     #[cfg(unix)]
     if let Some(home) = std::env::var_os("HOME") {

--- a/crates/op-acp/src/client_tests.rs
+++ b/crates/op-acp/src/client_tests.rs
@@ -688,3 +688,27 @@ fn remote_connector_uses_explicit_rustls_configuration() {
     assert_eq!(config.max_message_size, Some(MAX_INBOUND_FRAME_BYTES));
     assert_eq!(config.max_frame_size, Some(MAX_INBOUND_FRAME_BYTES));
 }
+
+/// Same rule as the chat spawn resolver: on Windows the executable extensions
+/// have to be probed before the bare name, because `is_executable_candidate`
+/// is only an `is_file()` check there and `npm i -g` leaves an extensionless
+/// POSIX shell script sitting next to the `.cmd` shim.
+#[cfg(windows)]
+#[test]
+fn windows_candidates_try_executable_extensions_before_the_bare_name() {
+    let dir = std::path::Path::new(r"C:\tools\bin");
+    let path = std::env::join_paths([dir]).unwrap();
+    let candidates = command_candidates("codex", &path.to_string_lossy());
+
+    assert_eq!(
+        &candidates[..6],
+        &[
+            dir.join("codex.exe"),
+            dir.join("codex.cmd"),
+            dir.join("codex.bat"),
+            dir.join("codex.com"),
+            dir.join("codex.ps1"),
+            dir.join("codex"),
+        ]
+    );
+}

--- a/crates/op-host-services/src/chat_spawn.rs
+++ b/crates/op-host-services/src/chat_spawn.rs
@@ -377,9 +377,13 @@ pub(crate) fn resolve_binary(name: &str) -> Option<PathBuf> {
 fn resolve_binary_from(name: &str, path_env: &OsStr, fallbacks: &[PathBuf]) -> Option<PathBuf> {
     for dir in std::env::split_paths(path_env).filter(|dir| !dir.as_os_str().is_empty()) {
         let candidate = dir.join(name);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
+        // Windows first: `CreateProcessW` cannot run an extensionless file, and
+        // `npm i -g` writes three of them into its bin directory — a POSIX
+        // `foo` shell script for Git Bash alongside `foo.cmd` and `foo.ps1`.
+        // Probing the bare name first picks that shell script, which then
+        // spawns as os error 193 ("not a valid Win32 application"). The
+        // fallback list below and `model_discovery` already order the bare
+        // name last for this reason.
         #[cfg(windows)]
         for ext in &["exe", "cmd", "bat", "ps1"] {
             let mut with_ext = candidate.clone();
@@ -387,6 +391,9 @@ fn resolve_binary_from(name: &str, path_env: &OsStr, fallbacks: &[PathBuf]) -> O
             if with_ext.is_file() {
                 return Some(with_ext);
             }
+        }
+        if candidate.is_file() {
+            return Some(candidate);
         }
     }
     fallbacks.iter().find(|path| path.is_file()).cloned()

--- a/crates/op-host-services/src/chat_spawn_resolver_tests.rs
+++ b/crates/op-host-services/src/chat_spawn_resolver_tests.rs
@@ -111,3 +111,24 @@ fn runtime_path_for_bare_binary_keeps_base_unchanged() {
     let base = std::env::join_paths([std::env::temp_dir().join("bin")]).unwrap();
     assert_eq!(runtime_path_for(Path::new("codex"), &base), base);
 }
+
+/// `npm i -g` writes three files into its bin directory: a POSIX `foo` shell
+/// script for Git Bash next to `foo.cmd` and `foo.ps1`. Windows cannot spawn
+/// the extensionless one — `CreateProcessW` returns os error 193 — so the
+/// resolver has to reach the shim, not the shell script.
+#[cfg(windows)]
+#[test]
+fn resolver_prefers_the_windows_shim_over_the_extensionless_npm_script() {
+    let temp = TestDir::new();
+    let bin = temp.0.join("npm");
+    fs::create_dir_all(&bin).unwrap();
+    fs::write(bin.join("codex"), "#!/bin/sh\n").unwrap();
+    fs::write(bin.join("codex.cmd"), "@echo off\r\n").unwrap();
+    fs::write(bin.join("codex.ps1"), "").unwrap();
+    let path_env = std::env::join_paths([&bin]).unwrap();
+
+    assert_eq!(
+        resolve_binary_from("codex", &path_env, &[]),
+        Some(bin.join("codex.cmd"))
+    );
+}


### PR DESCRIPTION
Completes the reordering #191 made in `model_discovery`. Two resolvers still had the original order.

## What breaks

`npm install -g` on Windows writes **three** files into its bin directory: a POSIX `foo` shell script (for Git Bash / MSYS) next to `foo.cmd` and `foo.ps1`. The extensionless one is a real file, so `is_file()` succeeds on it — but `CreateProcessW` cannot execute it, and the spawn dies with **os error 193, "%1 is not a valid Win32 application."**

**`chat_spawn::resolve_binary_from`** returned the bare name before ever testing an extension:

```rust
let candidate = dir.join(name);
if candidate.is_file() {
    return Some(candidate);      // ← the sh script wins
}
#[cfg(windows)]
for ext in &["exe", "cmd", "bat", "ps1"] { ... }
```

`build_command` then sees a path separator and takes the direct-spawn arm, so nothing recovers. This resolver is the single funnel for the chat CLIs — `chat_subprocess`, `model_discovery::resolve_cli`, `cli_provider_probe`, `chat_http_server`.

**`op_acp::client::command_candidates`** queues candidates in the same order:

```rust
let base = dir.join(command);
out.push(base.clone());          // ← bare name queued first
#[cfg(windows)]
for ext in ["exe", "cmd", "bat", "com", "ps1"] { out.push(base.with_extension(ext)); }
```

`is_executable_candidate` is only an `is_file()` check off Unix, so `resolve_local_command` picks the shell script. `build_local_command` dispatches on the *resolved* extension — `.ps1` → powershell, `.cmd`/`.bat` → `cmd /d /c`, else direct spawn — so an extensionless resolution lands in the `else` arm and hits 193 as well.

**Symptom:** an npm-installed agent CLI is found (so there is no "not installed" message) but never runs. Model discovery comes back empty, the agent card reads disconnected, and a turn fails with the raw spawn error. On a machine where the CLI was installed as a real `.exe` it works, which makes the reports look inconsistent.

## The fix

Probe the executable extensions first on Windows, bare name last. This is the same order #191 established, and the same order two *neighbouring* code paths already use:

- `chat_spawn::well_known_install_paths` — `for ext in &["exe", "cmd", "bat", "ps1", ""]`
- `op_acp::client`'s `%APPDATA%\npm` fallback — extensions only, no bare name

On Unix nothing changes: both loops are `#[cfg(windows)]`, and the bare name stays first where it is the norm.

## How verified

Platform: Windows 11 x64, toolchain 1.94.1 (`rust-toolchain.toml` pin), branch `v0.8.5` at `ab82e8b2`.

The three-file npm layout this depends on is real — `%APPDATA%\npm` on my machine holds `mimo`, `mimo.cmd`, `mimo.ps1`, which is exactly the shape the resolver was tripping over.

Two `#[cfg(windows)]` regression tests, one per resolver. The chat-spawn one writes the real three-file layout into a temp dir; the ACP one asserts candidate order directly, so it needs no filesystem.

**Fail before** — with both call sites restored to their original order:

```
---- chat_spawn::resolver_tests::resolver_prefers_the_windows_shim_over_the_extensionless_npm_script ----
assertion `left == right` failed
  left:  Some("...\openpencil-chat-spawn-resolver-41596-0\npm\codex")
 right:  Some("...\openpencil-chat-spawn-resolver-41596-0\npm\codex.cmd")

---- client::tests::windows_candidates_try_executable_extensions_before_the_bare_name ----
assertion `left == right` failed
  left:  ["C:\tools\bin\codex", "...codex.exe", "...codex.cmd", "...codex.bat", "...codex.com", "...codex.ps1"]
 right:  ["C:\tools\bin\codex.exe", "...codex.cmd", "...codex.bat", "...codex.com", "...codex.ps1", "C:\tools\bin\codex"]
```

`left` in the first one is the npm shell script — the file that spawns as 193.

**Pass after:**

```
$ cargo test -p op-acp
test result: ok. 43 passed; 0 failed

$ cargo test -p op-host-services --lib resolver_prefers
test chat_spawn::resolver_tests::resolver_prefers_path_and_preserves_the_selected_path ... ok
test chat_spawn::resolver_tests::resolver_prefers_the_windows_shim_over_the_extensionless_npm_script ... ok
test result: ok. 2 passed; 0 failed
```

Gates:

- `cargo test -p op-host-services` → `1156 passed; 2 failed`. Both failures (`chat_subprocess::tests::antigravity_and_grok_use_documented_one_shot_flags`, `chat_subprocess::tests::for_cli_claude_code_seeds_print_stream_json_flags`) reproduce identically, with identical messages, on a clean `v0.8.5` checkout with this change stashed — pre-existing and unrelated. They assert extensionless binary names against a host where the CLI resolves as `.exe`.
- `cargo fmt --all -- --check` → clean
- `cargo clippy -p op-acp -p op-host-services --all-targets -- -D warnings` → clean
