### PR TITLE
fix(release): keep the vsix daemon binary out of the release assets

### DIFF
--- a/tools/flatten-release-artifacts.sh
+++ b/tools/flatten-release-artifacts.sh
@@ -38,6 +38,13 @@ copied=0
 while IFS= read -r -d '' artifact; do
     name=${artifact##*/}
     case "$name" in
+        # The VS Code extension's bundled daemon. It rides inside each
+        # platform vsix and is not a release asset of its own; without this
+        # arm its Windows build matches `*.exe` below, once per Windows
+        # target, so the duplicate-basename guard rejects every release.
+        op-host-web-server | op-host-web-server.exe)
+            continue
+            ;;
         *.tar.gz | *.zip | *.dmg | *.exe | *.AppImage | *.deb | *.tgz | *.vsix | *.apk | *.aab | SHA256SUMS.android.txt)
             ;;
         *)

--- a/tools/flatten-release-artifacts.test.sh
+++ b/tools/flatten-release-artifacts.test.sh
@@ -15,6 +15,20 @@ make_fixture() {
     mkdir -p "$root/desktop" "$root/cli" "$root/sdk" "$root/vsix" "$root/android"
     printf 'desktop\n' > "$root/desktop/openpencil-desktop-linux-x86_64.tar.gz"
     printf 'cli\n' > "$root/cli/op-cli-linux-x86_64.tar.gz"
+    printf 'setup-x64\n' > "$root/desktop/OpenPencil-0.8.5-x64-win-setup.exe"
+    printf 'setup-arm64\n' > "$root/desktop/OpenPencil-0.8.5-arm64-win-setup.exe"
+    # `openpencil-daemon-<label>` artifacts also match release-draft's
+    # `openpencil-*` download pattern, so the flattener sees them.
+    for label in macos-aarch64 macos-x86_64 linux-x86_64 linux-aarch64; do
+        mkdir -p "$root/openpencil-daemon-${label}"
+        printf 'daemon-%s\n' "$label" \
+            > "$root/openpencil-daemon-${label}/op-host-web-server"
+    done
+    for label in windows-x86_64 windows-aarch64; do
+        mkdir -p "$root/openpencil-daemon-${label}"
+        printf 'daemon-%s\n' "$label" \
+            > "$root/openpencil-daemon-${label}/op-host-web-server.exe"
+    done
     for index in 1 2 3; do
         printf 'sdk-%s\n' "$index" > "$root/sdk/sdk-${index}.tgz"
     done
@@ -51,6 +65,12 @@ make_fixture "$valid"
 test -f "$temporary/release/OpenPencil-0.8.5-android.apk"
 test -f "$temporary/release/OpenPencil-0.8.5-android.aab"
 test ! -e "$temporary/release/internal-build.log"
+# The Windows installers are the `.exe` assets a release publishes.
+test -f "$temporary/release/OpenPencil-0.8.5-x64-win-setup.exe"
+test -f "$temporary/release/OpenPencil-0.8.5-arm64-win-setup.exe"
+# The vsix's bundled daemon is not one of them, on either platform.
+test ! -e "$temporary/release/op-host-web-server"
+test ! -e "$temporary/release/op-host-web-server.exe"
 
 duplicate=$temporary/duplicate
 make_fixture "$duplicate"


### PR DESCRIPTION
Reported as #238.

## What breaks

`rust-release.yml` uploads the VS Code extension's daemon binary as its own artifact, with this comment:

```yaml
# Raw daemon binary for the platform vsix (the extension's bundled
# runtime). No archive extension, so release-draft's flatten step
# never picks it up as a release file on its own.
- name: Upload daemon binary for the VS Code extension
  ...
    name: openpencil-daemon-${{ matrix.label }}
```

The premise holds on Unix. It does not hold on Windows, where the binary is `op-host-web-server.exe` — and `*.exe` is one of the release-asset patterns the flattener accepts:

```sh
case "$name" in
    *.tar.gz | *.zip | *.dmg | *.exe | *.AppImage | *.deb | *.tgz | *.vsix | *.apk | *.aab | SHA256SUMS.android.txt)
```

`release-draft` downloads with `pattern: openpencil-*`, and `openpencil-daemon-<label>` matches it. That pattern is deliberate (`ci_workflow.rs::release_workflow_downloads_only_openpencil_release_artifacts` pins it so Docker build-metadata artifacts stay out), so the daemon reaching `dist/` is correct — it is the flatten filter that has to know what it is looking at.

Two consequences, one already shipped and one pending:

**1. It shipped as a public release asset.** v0.8.4 published a bare, arch-unlabelled `op-host-web-server.exe`:

```
$ gh release view v0.8.4 --repo ZSeven-W/openpencil --json assets \
    --jq '.assets[] | select(.name | startswith("op-host-web-server")) | "\(.name)  \(.size)"'
op-host-web-server.exe  68272640
```

Every other asset carries its platform (`op-cli-windows-aarch64.zip`, `openpencil-desktop-windows-x86_64.zip`, `OpenPencil-0.8.4-x64-win-setup.exe`). This one does not, because it was never meant to be there — the old inline `find … -exec cp {} release-files/` overwrote in place, so exactly one of the two Windows daemons survived and its architecture became whichever the `find` order happened to pick. That is #238: an x64 user downloads it and Windows refuses to start it.

**2. It now fails the release outright.** `f9fa9d02` moved the flatten step into this script and added a duplicate-basename guard. The build matrix has two Windows targets (`windows-x86_64`, `windows-aarch64`), both required by the vsix step, and both emit `op-host-web-server.exe`. So what used to be a silent overwrite is now a hard stop.

## Fail-before

Extending `make_fixture` with the daemon artifacts the release actually produces — six `openpencil-daemon-<label>/` directories, laid out the way `actions/download-artifact` writes them — reproduces it against the unmodified script:

```
$ bash tools/flatten-release-artifacts.test.sh
error: duplicate release artifact basename: op-host-web-server.exe
EXIT=1
```

## After

```
$ bash tools/flatten-release-artifacts.test.sh
flatten-release-artifacts.test.sh: release asset fixtures passed.
EXIT=0
```

and the staged set on the full six-label fixture:

```
OpenPencil-0.8.5-android.aab      OpenPencil-0.8.5-arm64-win-setup.exe
OpenPencil-0.8.5-android.apk      OpenPencil-0.8.5-x64-win-setup.exe
SHA256SUMS.android.txt            editor-1.vsix … editor-6.vsix
op-cli-linux-x86_64.tar.gz        openpencil-desktop-linux-x86_64.tar.gz
sdk-1.tgz  sdk-2.tgz  sdk-3.tgz
flatten-release-artifacts: staged 16 verified release files
```

## The fix

One `case` arm, skipping the daemon binary by name before the extension patterns are consulted. It restores exactly what the workflow comment already says is supposed to happen.

## Pinned

The new fixture asserts in both directions, and both assertions hold before and after — this narrows the filter, it does not widen it:

- `OpenPencil-0.8.5-x64-win-setup.exe` and `OpenPencil-0.8.5-arm64-win-setup.exe` still stage. They are the `.exe` assets a release publishes, and they are what the `*.exe` arm is for.
- `op-host-web-server` and `op-host-web-server.exe` do not stage, on either platform.

The four existing rejection fixtures (duplicate basename, tampered Android checksum, extra APK, symlink) are untouched and still pass.

## Not in scope

#238 also asks for an x64 daemon download. That is a distribution decision, not a defect: today the daemon is shipped inside the six platform `.vsix` files, and `win32-x64` already carries the x64 build. This change only stops the unlabelled copy from leaking out beside them and unblocks the next tag; whether to publish arch-labelled daemon assets as well is a separate call.

## Verification

```
bash tools/flatten-release-artifacts.test.sh
cargo test -p op-host-web --test ci_workflow      # 18 passed — the workflow contracts, incl. the flattener assertions
```

Run on Windows with `rustc 1.94.1` (the pinned toolchain) and Git Bash. One environment note that is not part of this change: Git-for-Windows' `sha256sum` defaults to binary mode and writes ` *name`, which the fixture's existing `awk 'NF == 2 && $1 ~ /^[0-9a-f]{64}$/'` handoff check does not accept, so the shell test was run with a text-mode (`-t`) `sha256sum` on PATH. GNU coreutils, as on the CI runners, is text-mode by default and needs no such thing.
