### PR TITLE
fix(html): stop a non-ascii css prelude from panicking the import

### DIFF
--- a/crates/op-html/src/resources_css_imports.rs
+++ b/crates/op-html/src/resources_css_imports.rs
@@ -226,7 +226,7 @@ fn at_keyword(prelude: &str, name: &str) -> bool {
     let expected_len = name.len() + 1;
     prelude
         .get(..expected_len)
-        .is_some_and(|prefix| prefix[0..1].eq("@") && prefix[1..].eq_ignore_ascii_case(name))
+        .is_some_and(|prefix| prefix.starts_with('@') && prefix[1..].eq_ignore_ascii_case(name))
         && prelude[expected_len..]
             .chars()
             .next()
@@ -431,5 +431,41 @@ mod tests {
         assert!(warnings.is_empty(), "{warnings:?}");
         assert!(output.contains(".主题{color:red}"));
         assert!(output.contains(r#".按钮{content:"你好"}"#));
+    }
+
+    #[test]
+    fn a_prelude_opening_on_a_non_ascii_character_is_not_an_at_keyword() {
+        // The three non-ASCII cases above all keep an ASCII byte first. A
+        // stylesheet may open on a multi-byte one instead — a UTF-8 BOM
+        // ahead of `@charset` is the everyday shape, and `decode_css_bytes`
+        // only strips it from a linked sheet, not from an inline `<style>`.
+        // None of these are at-rules this scanner handles; each must simply
+        // say so and leave the sheet alone.
+        let fetcher = |_: &str| None;
+        for source in [
+            "\u{feff}@charset \"utf-8\";.root{color:red}",
+            "\u{feff}@layer base;.root{color:red}",
+            "\u{feff}@import 'a.css';.root{color:red}",
+            "中文;.root{color:red}",
+        ] {
+            let (output, _) = expand(source, &fetcher);
+            assert!(
+                output.contains(".root{color:red}"),
+                "source: {source:?}, output: {output:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ascii_charset_and_layer_preludes_keep_their_meaning() {
+        let fetcher = |_: &str| Some(b".imported{color:red}".to_vec());
+        let (output, warnings) = expand(
+            "@charset \"utf-8\";@layer base;@import 'a.css';.root{color:blue}",
+            &fetcher,
+        );
+        assert!(warnings.is_empty(), "{warnings:?}");
+        assert!(output.starts_with("@charset \"utf-8\";@layer base;"));
+        assert!(output.contains(".imported{color:red}"));
+        assert!(output.contains(".root{color:blue}"));
     }
 }


### PR DESCRIPTION
## What breaks

`at_keyword` decides whether a CSS statement's prelude is `@charset` / `@layer` / `@import`. It bounds the read with `get(..)`, then indexes by byte anyway:

```rust
fn at_keyword(prelude: &str, name: &str) -> bool {
    let expected_len = name.len() + 1;
    prelude
        .get(..expected_len)
        .is_some_and(|prefix| prefix[0..1].eq("@") && prefix[1..].eq_ignore_ascii_case(name))
```

`get(..expected_len)` only proves that byte `name.len() + 1` is a char boundary. It says nothing about byte 1 — and `prefix[0..1]` requires byte 1 to be one. When the prelude opens on a multi-byte character, it is not:

```
byte index 1 is not a char boundary; it is inside '\u{feff}' (bytes 0..3) of `﻿@char`
```

The panic unwinds out of `expand_stylesheet_imports`, so the whole HTML import dies rather than the at-rule simply not matching.

**Reaching it.** `expand_inner` calls `at_keyword(prelude, "charset")` on the first `;`-terminated top-level statement of every stylesheet, and `prelude` is that statement verbatim. A UTF-8 BOM ahead of `@charset` is the everyday case: it is the exact input CSS specifies a `@charset` interacting with, and it is what most Windows editors write. `css_encoding::decode_css_bytes` strips it — but only from a **linked** sheet's bytes. An inline `<style>` goes straight from the DOM into `expand_stylesheet_imports` with nothing in between (`stylesheets.rs::extend_author_rules`, the `StylesheetSource::Inline` arm), so the BOM arrives intact.

End-to-end, through the public entry point:

```rust
let source = "<style>\u{feff}@charset \"utf-8\";p{color:red}</style><p>hello</p>";
import_html(source, &HtmlImportOptions::default());
```

```
running 1 test
thread 'e2e_bom_inline_style' panicked at crates\op-html\src\resources_css_imports.rs:229:37:
byte index 1 is not a char boundary; it is inside '\u{feff}' (bytes 0..3) of `﻿@char`
test e2e_bom_inline_style ... FAILED
```

A BOM is not the only way in — any prelude whose first character is multi-byte does it, `中文;` included — but it is the one a user hits without trying.

This is also why the module's three existing non-ASCII tests miss it. `top_level_scan_accepts_non_ascii_selectors`, `top_level_scan_ignores_delimiters_in_non_ascii_strings_comments_and_urls` and `expands_import_with_non_ascii_url_and_rules` all put the non-ASCII bytes *after* an ASCII first byte, which is exactly the position `prefix[0..1]` is safe in.

## Fail-before

New unit test, against unmodified `at_keyword`:

```
$ cargo test -p op-html -- at_keyword ascii_charset_and_layer non_ascii
running 5 tests
test resources::css_imports::tests::top_level_scan_accepts_non_ascii_selectors ... ok
test resources::css_imports::tests::top_level_scan_ignores_delimiters_in_non_ascii_strings_comments_and_urls ... ok
test resources::css_imports::tests::ascii_charset_and_layer_preludes_keep_their_meaning ... ok
test resources::css_imports::tests::expands_import_with_non_ascii_url_and_rules ... ok
test resources::css_imports::tests::a_prelude_opening_on_a_non_ascii_character_is_not_an_at_keyword ... FAILED

thread '...' panicked at crates\op-html\src\resources_css_imports.rs:229:37:
byte index 1 is not a char boundary; it is inside '\u{feff}' (bytes 0..3) of `﻿@char`

test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 477 filtered out
```

## After

```
$ cargo test -p op-html -- at_keyword ascii_charset_and_layer non_ascii
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 477 filtered out

$ cargo test -p op-html
test result: ok. 482 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

and the end-to-end case:

```
running 1 test
imported 1 root node(s)
test e2e_bom_inline_style ... ok
```

## The fix

```diff
-.is_some_and(|prefix| prefix[0..1].eq("@") && prefix[1..].eq_ignore_ascii_case(name))
+.is_some_and(|prefix| prefix.starts_with('@') && prefix[1..].eq_ignore_ascii_case(name))
```

`starts_with('@')` is a `char` pattern, so it answers instead of panicking — and because `@` is one ASCII byte, `&&` short-circuits such that `prefix[1..]` is only reached once byte 1 is known to be a boundary. Same for `prelude[expected_len..]` on the next line, which `get(..expected_len)` had already covered.

## Pinned

`ascii_charset_and_layer_preludes_keep_their_meaning` is the non-widening check and passes **both before and after** (see the fail-before run above — 4 passed includes it): `@charset "utf-8";@layer base;@import 'a.css';.root{color:blue}` still passes the first two through untouched, still expands the `@import`, and still raises no warning.

The other four existing tests in the module are unchanged and still pass, as does the rest of the crate (482).

## Verification

```
cargo test -p op-html                                     # 482 passed
cargo fmt -p op-html -- --check                           # clean
cargo clippy -p op-html --all-targets -- -D warnings      # clean
```

Windows, `rustc 1.94.1` — the pinned toolchain, no override needed.
