### PR TITLE
fix(ai): keep the radius context cut on a char boundary

### DIFF
--- a/crates/op-ai-skills/src/style_guide/token_table.rs
+++ b/crates/op-ai-skills/src/style_guide/token_table.rs
@@ -512,10 +512,11 @@ fn px_values(line: &str) -> Vec<(i64, String)> {
         // Up to the next clause break — that is where this number's
         // description ends and the next one's begins.
         let tail = &line[index..];
-        let end = tail
-            .find([',', ';', '.', ')', '(', '—'])
-            .unwrap_or(tail.len())
-            .min(48);
+        let end = tail.floor_char_boundary(
+            tail.find([',', ';', '.', ')', '(', '—'])
+                .unwrap_or(tail.len())
+                .min(48),
+        );
         out.push((value, tail[..end].to_string()));
     }
     out

--- a/crates/op-ai-skills/src/style_guide/token_table_tests.rs
+++ b/crates/op-ai-skills/src/style_guide/token_table_tests.rs
@@ -220,3 +220,29 @@ fn the_palette_floor_reports_colours_with_their_own_role_text() {
     assert_eq!(prose.len(), 2);
     assert_eq!(prose[0].color, "#101014");
 }
+
+/// A radius sentence whose description is not written in Latin script. The
+/// per-number context is cut at 48 bytes, and a guide's prose is arbitrary
+/// author text — most CJK and Hangul characters are three bytes each, so that
+/// cut lands mid-character on ordinary input.
+#[test]
+fn a_radius_line_written_in_another_script_is_read_and_classified() {
+    for line in [
+        "Corner radius: 12px  卡片与面板容器的外框圆角，用于所有卡片与弹层",
+        "Corner radius: 12px卡片与面板容器的外框圆角，用于所有卡片与弹层",
+        "Corner radius: 12px 카드와 패널 컨테이너의 바깥 테두리 라운드에 사용",
+    ] {
+        let content = format!("# G\n\n## Shape\n\n{line}\n");
+        let values = extract_style_guide_values(&content);
+        // Nothing in these says which role the radius is for, so nothing is
+        // invented — but the scan has to reach that answer, not panic on
+        // the way.
+        assert_eq!(values.radius, StyleRadius::default(), "line: {line}");
+    }
+
+    // The same sentence with an English role cue still classifies.
+    let mixed = extract_style_guide_values(
+        "# G\n\n## Shape\n\nCorner radius: 24px card 카드와 패널 컨테이너의 바깥 테두리\n",
+    );
+    assert_eq!(mixed.radius.card, Some(24));
+}


### PR DESCRIPTION
## What breaks

`px_values` collects each `<digits>px` on a radius line together with the words that qualify it, and caps that context:

```rust
let tail = &line[index..];
let end = tail
    .find([',', ';', '.', ')', '(', '—'])
    .unwrap_or(tail.len())
    .min(48);
out.push((value, tail[..end].to_string()));
```

Both inputs to `.min(48)` are char boundaries — `find` returns one, `tail.len()` is one — but `48` is not one of them. It is a raw byte count against arbitrary author prose, and `tail[..end]` needs a boundary:

```
byte index 48 is not a char boundary; it is inside '于' (bytes 46..49)
    of `px  卡片与面板容器的外框圆角，用于所有卡片与弹层`
```

Most CJK and Hangul characters are three UTF-8 bytes, so 48 bytes is about sixteen characters into the description — well inside an ordinary sentence, and a boundary only when the byte count happens to divide evenly. The Latin-script case is why this has not been seen: for ASCII every byte index is a boundary, so `min(48)` is always safe there.

**Reaching it.** This is the gap-filler path, and the module's own header says what it is for: files from "the wider `DESIGN.md` ecosystem" that the corpus grammar returns `None` for. Those are the guides a user brings in. `import_design_md` registers one, and the Asset Center's style tab then calls `extract_style_guide_values(&guide.content)` from `StyleGuideCard::from_guide` — a paint path — so the panic lands while drawing the card for the file the user just imported. A design guide written in Chinese, Japanese or Korean that describes its corner radii in its own language is not an edge case for this project.

## Fail-before

New test, against unmodified `px_values` (three real-shaped radius lines, plus one mixed-script line that must still classify):

```
$ cargo test -p op-ai-skills -- another_script each_radius_is_classified heading_fonts_and_prose_radii
running 3 tests
test ...::each_radius_is_classified_by_its_own_words ... ok
test ...::heading_fonts_and_prose_radii_are_read ... ok
test ...::a_radius_line_written_in_another_script_is_read_and_classified ... FAILED

thread '...' panicked at crates\op-ai-skills\src\style_guide\token_table.rs:519:30:
byte index 48 is not a char boundary; it is inside '于' (bytes 46..49)
    of `px  卡片与面板容器的外框圆角，用于所有卡片与弹层`

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 204 filtered out
```

The Korean line fails the same way (`inside '두' (bytes 46..49)`), as does the no-space Chinese variant (`inside '所' (bytes 47..50)`) — the three differ only in where the misalignment falls.

## After

```
$ cargo test -p op-ai-skills -- another_script each_radius_is_classified heading_fonts_and_prose_radii radii_are_only_read
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 203 filtered out

$ cargo test -p op-ai-skills
test result: ok. 207 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## The fix

Floor the cap to the nearest boundary at or below it, leaving the two values that were already boundaries alone. `str::floor_char_boundary` is std and stable since 1.88; the workspace pins `rust-version = "1.94"`.

**This is byte-for-byte a no-op on Latin-script input.** `floor_char_boundary(n)` returns `n` whenever `n` is already a boundary, and in an ASCII string every index is — so no existing guide's context string moves by a character.

## Pinned

Two existing tests are the non-widening check, and both pass **before and after** (visible in the fail-before run above):

- `each_radius_is_classified_by_its_own_words` — "9999px pill buttons, 10px UI radii, 24px card radii" still resolves to `card: Some(24)` (not the 10px UI radius) and `button: Some(9999)`. This is the test that proves the cap still cuts per-number rather than per-line.
- `heading_fonts_and_prose_radii_are_read` — the corpus fixture still reads `button: Some(9999)`, `card: Some(24)`.

`radii_are_only_read_from_lines_that_claim_to_be_radii` and the whole-corpus regression lock `the_token_dialect_never_changes_a_corpus_guides_values` also still pass — the latter runs both extraction paths across every shipped guide and asserts byte-identical values.

The new test's own last assertion pins classification through the fix: `24px card 카드와 패널 컨테이너의 바깥 테두리` still yields `card: Some(24)`, so the context is still being read, not just kept from panicking.

## Verification

```
cargo test -p op-ai-skills                                     # 207 passed
cargo fmt -p op-ai-skills -- --check                           # clean
cargo clippy -p op-ai-skills --all-targets -- -D warnings      # clean
```

Windows, `rustc 1.94.1` — the pinned toolchain, no override needed.
