### PR TITLE
fix(design-lint): guard the transparent-alpha test against a non-ascii fill

### DIFF
--- a/crates/op-design-lint/src/detectors/typography.rs
+++ b/crates/op-design-lint/src/detectors/typography.rs
@@ -327,7 +327,7 @@ fn first_solid_color(fills: Option<&Vec<PenFill>>) -> Option<String> {
 /// True for a 9-char `#RRGGBBAA` hex whose alpha pair is `00` — a fully
 /// transparent solid, treated the same as `opacity == 0`.
 fn is_transparent_hex(color: &str) -> bool {
-    color.len() == 9 && color[7..].eq_ignore_ascii_case("00")
+    color.len() == 9 && color.is_ascii() && color[7..].eq_ignore_ascii_case("00")
 }
 
 /// Port of `isLargeText` (`detectors-typography.ts:87-99`). WCAG 2.x large
@@ -434,6 +434,57 @@ mod tests {
         assert!(
             detect_text_bg_contrast(&root, &doc(json!({"version": "1.0", "children": []})))
                 .is_empty()
+        );
+    }
+
+    /// A fill color the model wrote as a name rather than a hex must not
+    /// panic the detector. `深蓝色` is nine UTF-8 bytes, so the byte-length
+    /// test in `is_transparent_hex` accepts it and the `[7..]` slice lands
+    /// inside the last character.
+    #[test]
+    fn tolerates_a_non_ascii_fill_color() {
+        let root = node(json!({
+            "type": "frame", "id": "page",
+            "fill": [{"type": "solid", "color": "#FFFFFF"}],
+            "children": [
+                {
+                    "type": "text", "id": "t1", "content": "Hello",
+                    "fill": [{"type": "solid", "color": "深蓝色"}]
+                }
+            ]
+        }));
+        // The color does not resolve, so the node is skipped — but the walk
+        // must finish instead of panicking.
+        assert!(
+            detect_text_bg_contrast(&root, &doc(json!({"version": "1.0", "children": []})))
+                .is_empty()
+        );
+    }
+
+    /// The transparent-alpha skip itself is unchanged: a `#RRGGBBAA` fill
+    /// with alpha `00` is passed over so the next fill supplies the color.
+    #[test]
+    fn skips_a_zero_alpha_fill_for_the_next_one() {
+        let root = node(json!({
+            "type": "frame", "id": "page",
+            "fill": [{"type": "solid", "color": "#FFFFFF"}],
+            "children": [
+                {
+                    "type": "text", "id": "t1", "content": "Hello",
+                    "fill": [
+                        {"type": "solid", "color": "#00000000"},
+                        {"type": "solid", "color": "#FCFCFC"}
+                    ]
+                }
+            ]
+        }));
+        let issues =
+            detect_text_bg_contrast(&root, &doc(json!({"version": "1.0", "children": []})));
+        assert_eq!(issues.len(), 1);
+        assert!(
+            issues[0].reason.contains("text=#FCFCFC"),
+            "the zero-alpha fill must be skipped: {}",
+            issues[0].reason
         );
     }
 


### PR DESCRIPTION
## What breaks

`typography.rs:329` decides whether a fill is fully transparent by slicing at
a fixed byte offset, guarded only by a byte-length test:

```rust
/// True for a 9-char `#RRGGBBAA` hex whose alpha pair is `00` — a fully
/// transparent solid, treated the same as `opacity == 0`.
fn is_transparent_hex(color: &str) -> bool {
    color.len() == 9 && color[7..].eq_ignore_ascii_case("00")
}
```

The doc comment says **9-char**; `len()` counts **bytes**. Any nine-byte
string reaches the slice, and `[7..]` panics when byte 7 is not a character
boundary. Three CJK characters are exactly nine bytes, so a fill color written
as a name rather than a hex — `深蓝色`, `浅灰色`, `天蓝色` — takes the process down:

```
byte index 7 is not a char boundary; it is inside '色' (bytes 6..9) of `深蓝色`
```

A non-hex color string is not an unexpected input here. `first_solid_color`
hands whatever it finds to `resolve_color_ref`, which passes any non-`$` value
straight through, and `skips_unresolvable_ref_fill` (`typography.rs:501`)
already pins that a color the detector cannot resolve is simply skipped. The
detector is meant to ignore this value; instead it panics before it gets the
chance.

## Where it runs

`is_transparent_hex` ← `first_solid_color` (`typography.rs:268`) ←
`check_text` / `ancestor_bg_color` ← `detect_text_bg_contrast` ←
`detect_all` (`detectors/mod.rs:82`) ← `detect_and_plan` (`plan.rs:98`) ←
`LintPreValidator::run_pre_validation_fixes` (`op-host-services/src/pre_validator.rs:66`),
which is the live pre-validator in both design paths —
`design_session.rs:101` (native design worker) and
`web_chat_standard.rs:613` (web chat generation).

The color it reads is the model's own. `batch_design`'s `normalize_fill`
(`op-mcp/src/batch_design_fill_normalize.rs:1`) rewrites a bare string fill to
`[{"type":"solid","color":<string>}]` without validating it, and
`PenFill::Solid`'s `color` is an unconstrained `String`. So a generation turn
where the model writes a Chinese color name instead of a hex reaches this
slice on the pre-validation pass.

## The sibling copies already guard it

Two other detectors in this crate do the same nine-byte alpha test, and both
check `is_ascii()` first:

```rust
// detectors/empty_filled_panel.rs:186
if color.len() == 9 && color.is_ascii() && color.starts_with('#') {

// detectors/top_anchored_bars.rs:367
    color.len() == 9
        && color.is_ascii()
        && color.starts_with('#')
```

`typography.rs` is the copy that was missed. This change adds the same
`is_ascii()` term and nothing else — which also makes the doc comment true,
since for ASCII nine bytes *is* nine chars.

## Fail-before

Against unmodified `upstream/main` (`e6c9bcef`), toolchain `1.94` as pinned by
`rust-toolchain.toml`:

```
$ cargo test -p op-design-lint typography

running 10 tests
...
test detectors::typography::tests::skips_a_zero_alpha_fill_for_the_next_one ... ok
test detectors::typography::tests::tolerates_a_non_ascii_fill_color ... FAILED

---- detectors::typography::tests::tolerates_a_non_ascii_fill_color stdout ----
thread '...' panicked at crates\op-design-lint\src\detectors\typography.rs:330:30:
byte index 7 is not a char boundary; it is inside '色' (bytes 6..9) of `深蓝色`

test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 218 filtered out
```

## After

```
$ cargo test -p op-design-lint typography
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 218 filtered out
```

Whole crate:

```
$ cargo test -p op-design-lint
     Running unittests src\lib.rs
test result: ok. 228 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     Running tests\parity.rs
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Not a widening

`skips_a_zero_alpha_fill_for_the_next_one` pins the behaviour the guard exists
for — a `#00000000` fill is still passed over so the next fill supplies the
color — and it **passes both before and after**. The existing suite
(`skips_transparent_wrapper_fill_to_real_bg`, `skips_unresolvable_ref_fill`,
`resolves_variable_ref_fills`, and the rest of the 228) is unchanged.

## Verification

```
cargo test -p op-design-lint
cargo fmt -p op-design-lint -- --check
cargo clippy -p op-design-lint --all-targets -- -D warnings
```

All clean. The defect is present on both `main` (`e6c9bcef`) and the current
`v0.8.5` branch.

## Related, not in this change

`op-orchestrator/src/text_contrast_repair.rs:286` carries a copy of this helper
whose doc comment says it is "mirrored from the detector's
`is_transparent_hex`" — it is missing the same guard. Kept out of this diff to
leave one defect per change; happy to send it separately.
